### PR TITLE
Bring back support of other filesystems for refind

### DIFF
--- a/src/modules/partition/partition.conf
+++ b/src/modules/partition/partition.conf
@@ -53,9 +53,9 @@ initialPartitioningChoice: none
 
 initialSwapChoice: none
 
-defaultFileSystemType:  "btrfs"
+defaultFileSystemType:  "xfs"
 
-availableFileSystemTypes:  ["btrfs","ext4"]
+availableFileSystemTypes:  ["xfs","btrfs","ext4","f2fs","zfs"]
 
 #enableLuksAutomatedPartitioning:    true
 


### PR DESCRIPTION
 The file system support in refind is to support booting directly from ext4/btrfs partitions, i.e. without a boot partition. But during the installation we create a boot partition in the FAT32 file system, so it makes no sense to limit the set of systems the root can be formatted in, because there is no boot loader there.