### PR TITLE
Enable ZFS In refind and add LTS ZFS module

### DIFF
--- a/src/modules/pacstrap/main.py
+++ b/src/modules/pacstrap/main.py
@@ -98,7 +98,7 @@ def run():
 
     if is_root_on_zfs:
         libcalamares.utils.debug("Root on ZFS")
-        base_packages += ["zfs-utils", "linux-cachyos-zfs"]
+        base_packages += ["zfs-utils", "linux-cachyos-zfs", "linux-cachyos-lts-zfs"]
     elif is_root_on_btrfs:
         libcalamares.utils.debug("Root on BTRFS")
         base_packages += ["snapper", "btrfs-assistant-git", "refind-btrfs" ]

--- a/src/modules/partition/partition.conf
+++ b/src/modules/partition/partition.conf
@@ -41,7 +41,7 @@ luksGeneration: luks2
 #
 # The default is true
 #
-allowZfsEncryption: false
+allowZfsEncryption: true
 
 # Correctly draw nested (e.g. logical) partitions as such.
 drawNestedPartitions:   false
@@ -55,7 +55,7 @@ initialSwapChoice: none
 
 defaultFileSystemType:  "btrfs"
 
-availableFileSystemTypes:  ["btrfs","ext4","xfs","f2fs"]
+availableFileSystemTypes:  ["btrfs","ext4","xfs","f2fs", "zfs"]
 
 #enableLuksAutomatedPartitioning:    true
 


### PR DESCRIPTION
Commit [a340c286f65074a836393f9079ca693eaf483ca8] (https://github.com/CachyOS/cachyos-calamares/commit/a340c286f65074a836393f9079ca693eaf483ca8) fixes the underlying issue of why there was a broken kernel param (Thanks vlad)
Also had to add the lts zfs module since the refind version ships with the LTS kernel by default