### PR TITLE
Change rEFInd partition layout, switch to new calamares schema and fix refind installation.

### DIFF
--- a/src/modules/bootloader/main.py
+++ b/src/modules/bootloader/main.py
@@ -825,7 +825,7 @@ def install_refind(efi_directory):
     kernel_params = " ".join(get_kernel_params(uuid))
     conf_path = os.path.join(installation_root_path, "boot/refind_linux.conf")
 
-    check_target_env_call(["refind-install"])
+    libcalamares.utils.host_env_process_output(["refind-install", "--root", installation_root_path])
 
     with open(conf_path, "r") as refind_file:
         filedata = [x.strip() for x in refind_file.readlines()]

--- a/src/modules/partition/partition.conf
+++ b/src/modules/partition/partition.conf
@@ -6,11 +6,15 @@
 # etc.) use just /boot.
 #
 # Defaults to "/boot/efi", may be empty (but weird effects ensue)
-efiSystemPartition:     "/boot/efi"
-
-efiSystemPartitionSize:     512M
-
+#efiSystemPartition:     "/boot/efi"
+#efiSystemPartitionSize:     512M
 # efiSystemPartitionName:     EFI
+
+efi:
+    mountPoint:         "/boot/efi"
+    recommendedSize:    512MiB
+    minimumSize:        50MiB
+    label:              "EFI"
 
 userSwapChoices:
     - none      # Create no swap, use no swap

--- a/src/modules/partition/partition.conf
+++ b/src/modules/partition/partition.conf
@@ -6,9 +6,9 @@
 # etc.) use just /boot.
 #
 # Defaults to "/boot/efi", may be empty (but weird effects ensue)
-efiSystemPartition:     "/boot"
+efiSystemPartition:     "/boot/efi"
 
-efiSystemPartitionSize:     2048M
+efiSystemPartitionSize:     512M
 
 # efiSystemPartitionName:     EFI
 
@@ -59,3 +59,13 @@ availableFileSystemTypes:  ["btrfs","ext4","xfs","f2fs", "zfs"]
 
 #enableLuksAutomatedPartitioning:    true
 
+partitionLayout:
+    - name: ""
+      filesystem: "ext4"
+      mountPoint: "/boot"
+      size: 2G
+      noEncrypt: true
+    - name: ""
+      filesystem: "unknown"
+      mountPoint: "/"
+      size: 100%


### PR DESCRIPTION
This switches the partition layout of refind from dual partition (one boot&efi and one root) to triple partition (one boot/efi, one /boot and root) This helps with dual booting systems like fedora and especially helps with windows as windows only creates a 100mb efi partition. The only thing that the system would place on the EFI would be refind itself. The boot images would be stored on the 2GB ext4 /boot partition. The triple partition also allows rEFInd to continue to support any filesystem as the only thing it has to read is the /boot which is ext4 which rEFInd can read natively. The names of the partition are intentionally left blank as to allow Calamares to decide them automatically. Filesystem "unknown" tells calamares to use the filesystem that the user has selected.
EDIT: This now includes the new schema for the EFI details that was merged from upstream a while back. This also now includes a fix for the duplicate mtab entries caused by running the refind-install script inside the chroot