### PR TITLE
Remove space_cache=v2 mount option

### DIFF
--- a/src/modules/mount/mount.conf
+++ b/src/modules/mount/mount.conf
@@ -50,7 +50,7 @@ mountOptions:
     - filesystem: efi
       options: [ defaults, umask=0077 ]
     - filesystem: btrfs
-      options: [ defaults, noatime, compress=zstd, space_cache=v2, commit=120 ]
+      options: [ defaults, noatime, compress=zstd, commit=120 ]
     - filesystem: btrfs_swap
       options: [ defaults, noatime ]
     - filesystem: ext4


### PR DESCRIPTION
It's default, so redundant.