### PR TITLE
[NEEDS TESTING] Change Btrfs subvolume layout

### DIFF
--- a/src/modules/mount/mount.conf
+++ b/src/modules/mount/mount.conf
@@ -34,15 +34,15 @@ btrfsSubvolumes:
     - mountPoint: /home
       subvolume: /@home
     - mountPoint: /root
-      subvolume: /@root
+      subvolume: /@/root
     - mountPoint: /srv
-      subvolume: /@srv
+      subvolume: /@/srv
     - mountPoint: /var/cache
-      subvolume: /@cache
+      subvolume: /@/var/cache
     - mountPoint: /var/tmp
-      subvolume: /@tmp
+      subvolume: /@/var/tmp
     - mountPoint: /var/log
-      subvolume: /@log
+      subvolume: /@/var/log
 
 mountOptions:
     - filesystem: default


### PR DESCRIPTION
The idea here is simple: Create Btrfs subvolumes in the same path where they are mounted to. This way, having them unmounted (as is the case when, for example, chrooting into the system for system repair) will not create hidden junk files in the paths where the subvolumes are normally mounted to.
The purpose of the subvolumes remains completely fulfilled, namely preventing the subvolume mount paths to be part of system snapshots.
@home subvolume is excluded from this change, so it remains fully compatible with Timeshift.
I have used this setup myself for a long time, but I'm not sure if this patch will actually work as intended, so probably needs testing.