### PR TITLE
plymouth: Add plymouth support and use CachyOS theme 

### DIFF
--- a/settings.conf
+++ b/settings.conf
@@ -69,6 +69,7 @@ sequence:
   - packages@online
   - luksbootkeyfile
   - luksopenswaphookcfg
+  - plymouthcfg
   - zfshostid
   - initcpiocfg
   - initcpio

--- a/settings_online.conf
+++ b/settings_online.conf
@@ -69,6 +69,7 @@ sequence:
   - packages@online
   - luksbootkeyfile
   - luksopenswaphookcfg
+  - plymouthcfg
   - zfshostid
   - initcpiocfg
   - initcpio

--- a/src/modules/bootloader/bootloader.conf
+++ b/src/modules/bootloader/bootloader.conf
@@ -30,7 +30,7 @@ loaderEntries:
   - "console-mode keep"
 
 # systemd-boot and refind support custom kernel params
-kernelParams: [ "quiet" ]
+kernelParams: [ "quiet","splash" ]
 
 # A list of kernel names that refind should accept as kernels
 refindKernelList: [ "linux-cachyos","linux","linux-cachyos-cfs","linux-cachyos-bore" ]

--- a/src/modules/pacstrap/pacstrap.conf
+++ b/src/modules/pacstrap/pacstrap.conf
@@ -60,6 +60,7 @@ basePackages:
   - systemd-boot-manager
   - xfsprogs
   - plymouth
+  - cachyos-plymouth-theme
 
 #
 # postInstallFiles is an array of file names which will be copied into the system

--- a/src/modules/pacstrap/pacstrap.conf
+++ b/src/modules/pacstrap/pacstrap.conf
@@ -59,6 +59,7 @@ basePackages:
   - which
   - systemd-boot-manager
   - xfsprogs
+  - plymouth
 
 #
 # postInstallFiles is an array of file names which will be copied into the system

--- a/src/modules/plymouthcfg/plymouthcfg.conf
+++ b/src/modules/plymouthcfg/plymouthcfg.conf
@@ -24,7 +24,7 @@
 # configuration set to that theme. It is up to plymouth to
 # deal with that.
 
-plymouth_theme: spinfinity
+plymouth_theme: cachyos
 
 
 


### PR DESCRIPTION
Adds plymouth support as default, this will add to the mkinitcpio.conf to the hooks array the "plymouth" hook.

Also, we need to set "splash" to the kernel cmdline. Tested with systemd-boot.

systemd-boot-manager also needs to set "splash" to the kernel cmdline.