### PR TITLE
Switch user creation to before online package installing and switch username to deck

### DIFF
--- a/settings_online.conf
+++ b/settings_online.conf
@@ -65,6 +65,7 @@ sequence:
   - locale
   - keyboard
   - localecfg
+  - users
   - shellprocess@before-online
   - shellprocess@drivers
   - packages@online
@@ -74,7 +75,6 @@ sequence:
   - zfshostid
   - initcpiocfg
   - initcpio
-  - users
   - networkcfg
   - hwclock
   - shellprocess@removeucode

--- a/src/modules/users/users.conf
+++ b/src/modules/users/users.conf
@@ -85,8 +85,8 @@ allowActiveDirectory: false
 
 presets:
     fullName:
-        value: "Gamer"
+        value: "Deck"
         editable: true
     loginName:
-        value: "gamer"
-        editable: false
+        value: "deck"
+        editable: true


### PR DESCRIPTION
This creates the user before installing online packages. This fixes the handheld edition .install Also allows the username to be edited
[Related PR](https://github.com/CachyOS/CachyOS-PKGBUILDS/pull/207)