### PR TITLE
netinstall: Add malcontent package to GNOME group

### DIFF
--- a/src/modules/netinstall/netinstall.yaml
+++ b/src/modules/netinstall/netinstall.yaml
@@ -272,6 +272,7 @@
     - gnome-themes-extra
     - gnome-tweaks
     - gnome-usage
+    - malcontent
     - libnma
     - gvfs
     - gvfs-afc


### PR DESCRIPTION
This fixes impossibility to configure installed apps in the “Apps” tab in gnome-control-center.