### PR TITLE
Make shell packages opt-in

### DIFF
--- a/src/modules/netinstall/netinstall.yaml
+++ b/src/modules/netinstall/netinstall.yaml
@@ -19,15 +19,19 @@
   selected: true
   critical: true
   packages:
-     - cachyos-fish-config
-     - cachyos-ananicy-rules
      - cachyos-hello
      - cachyos-kernel-manager
      - cachyos-packageinstaller
      - cachyos-settings
-     - cachyos-zsh-config
      - cachyos-micro-settings
      - cachyos-wallpapers
+- name: "CachyOS shell configuration"
+  description: "Shell packages for CachyOS"
+  hidden: false
+  selected: true
+  packages:
+     - cachyos-fish-config
+     - cachyos-zsh-config
 - name: "Base-devel + Common packages"
   description: "Recommended. Don't change unless you know what you're doing (generic)."
   hidden: false

--- a/src/modules/pacstrap/pacstrap.conf
+++ b/src/modules/pacstrap/pacstrap.conf
@@ -14,7 +14,6 @@ basePackages:
   - base
   - base-devel
   - btrfs-progs
-  - cachyos-fish-config
   - cachyos-hooks
   - cachyos-keyring
   - cachyos-mirrorlist

--- a/src/modules/shellprocess/shellprocess.conf
+++ b/src/modules/shellprocess/shellprocess.conf
@@ -99,3 +99,4 @@ script:
     - "-rm -rf /home/liveuser"
     - '-runuser ${USER} -c "cp -rf /etc/skel/. /home/${USER}/."'
     - '-runuser ${USER} -c "rm -rf /home/${USER}/{.xsession,.xprofile,.xinitrc}"'
+    - "-for shell in 'fish' 'zsh'; do [ -e /bin/$shell ] && chsh -s /bin/$shell ${USER} && break; done"

--- a/src/modules/users/users.conf
+++ b/src/modules/users/users.conf
@@ -79,7 +79,7 @@ allowWeakPasswordsDefault: false
 #   - write "rwxrwxrwx" (like the output of ls, with a - for unset bits)
 #   The following permissions mean the same thing: "o750", "rwxr-x---" .
 user:
-  shell: /bin/fish
+  shell: /bin/bash
   forbidden_names: [ root ]
   home_permissions: "o700"
 


### PR DESCRIPTION
This brings the default shell installation to shellprocess, so we can do this depending on whether the user has selected the fish or zsh configuration packages, which are put in a separate non-critical package group. I am not really pleased with this solution as it is quite hacky, but it will make some users happy.

Closes: https://github.com/CachyOS/cachyos-calamares/issues/30