### PR TITLE
Cleanup GNOME package group, separate GNOME apps to subgroup

### DIFF
--- a/src/modules/netinstall/netinstall.yaml
+++ b/src/modules/netinstall/netinstall.yaml
@@ -257,46 +257,43 @@
     - xdg-desktop-portal-kde
     - xsettingsd
 - name: "GNOME-Desktop"
-  description: "GNOME Desktop - designed to put you in control and get things done."
+  description: "GNOME desktop environment - designed to put you in control and get things done."
   hidden: false
   selected: false
   critical: true
   packages:
-    - adwaita-icon-theme
-    - eog
-    - evince
-    - file-roller
     - fwupd
     - gdm
     - gedit
-    - gnome
     - gnome-backgrounds
-    - gnome-calculator
+    - gnome-console
     - gnome-control-center
-    - gnome-disk-utility
     - gnome-keyring
-    - gnome-nettool
-    - gnome-power-manager
-    - gnome-screenshot
     - gnome-shell
-    - gnome-terminal
-    - gnome-themes-extra
     - gnome-tweaks
-    - gnome-usage
-    - malcontent
     - libnma
-    - gvfs
-    - gvfs-afc
-    - gvfs-gphoto2
-    - gvfs-mtp
-    - gvfs-nfs
-    - gvfs-smb
-    - nautilus
     - sushi
-    - totem
-    - qt6-wayland
-    - xdg-user-dirs-gtk
-    - xdg-desktop-portal-gnome
+  subgroups:
+      - name: "GNOME Apps"
+        description: "Additional software from the GNOME project"
+        critical: false
+        packages:
+          - papers
+          - loupe
+          - file-roller
+          - simple-scan
+          - gnome-disk-utility
+          - gnome-power-manager
+          - gnome-calculator
+          - gnome-nettool
+          - gnome-usage
+          - malcontent
+          - showtime
+          - gvfs-afc
+          - gvfs-nfs
+          - gvfs-smb
+          - gvfs-gphoto2
+          - gvfs-mtp
 - name: "Xfce4"
   description: "Xfce is a lightweight desktop environment for UNIX-like operating systems. It aims to be fast and low on system resources, while still being visually appealing and user friendly."
   hidden: false


### PR DESCRIPTION
- adwaita-icon-theme is hard dependency for GTK3/GTK4, so there's no need to specify it here.
- nautilus is now hard dependency for xdg-desktop-portal-gnome (https://gitlab.gnome.org/GNOME/xdg-desktop-portal-gnome/-/commit/b71b52c3a7e314e87a9dff9f238bea8bc86a3eef), xdg-desktop-portal-gnome is now hard dependency for gnome-session,  so there's no need to specify it here.
- gvfs and xdg-user-dirs-gtk are hard dependencies for nautilus.
- GNOME applications are separated into a separate package group, which is selected by default but not critical, so that users can decide which programs they want to have after system installation.

Fixes: https://github.com/CachyOS/cachyos-calamares/issues/43
Closes: https://github.com/CachyOS/cachyos-calamares/issues/101