### PR TITLE
Remove Kde dependency that pulled vlc

### DIFF
--- a/src/modules/netinstall/netinstall.yaml
+++ b/src/modules/netinstall/netinstall.yaml
@@ -217,6 +217,7 @@
     - dolphin
     - egl-wayland
     - gwenview
+    - haruna
     - konsole
     - kate
     - kdeconnect
@@ -247,7 +248,7 @@
     - xsettingsd
     - xdg-desktop-portal
     - xdg-desktop-portal-kde
-    - phonon-qt6-vlc
+    - phonon-qt6-mpv
 - name: "GNOME-Desktop"
   description: "GNOME Desktop - designed to put you in control and get things done."
   hidden: false


### PR DESCRIPTION
With [phonon-qt6-mpv](https://archlinux.org/packages/extra/x86_64/phonon-qt6-mpv/) now in extra, kde can now depend on a mpv backend that can take advantage of a [Kde Application](https://apps.kde.org/haruna/) for a video player.  If a full fledged video player isn't needed a terminal version is still available.  phonon mpv simply depends on libmpv.so, and that is provided by mpv.

(Wanted thoughts before pr'ing in other branches)