### PR TITLE
Install realtime-privileges by default and add user into realtime group

### DIFF
--- a/src/modules/netinstall/netinstall.yaml
+++ b/src/modules/netinstall/netinstall.yaml
@@ -147,6 +147,7 @@
           - alsa-utils
           - pavucontrol
           - pipewire-pulse
+          - realtime-privileges
           - wireplumber
           - pipewire-alsa
           - rtkit

--- a/src/modules/users/users.conf
+++ b/src/modules/users/users.conf
@@ -29,6 +29,7 @@ defaultGroups:
       must_exist: false
       system: true
     - audio
+    - realtime
 
 doAutologin:     false
 


### PR DESCRIPTION
Needed by PipeWire RT module and RPCS3 emulator. 