### PR TITLE
[shellprocess_removeucode.conf] adding a better timeout

### DIFF
--- a/src/modules/shellprocess/shellprocess_removeucode.conf
+++ b/src/modules/shellprocess/shellprocess_removeucode.conf
@@ -7,6 +7,7 @@ dontChroot: false
 
 script:
  - "/etc/calamares/scripts/remove-ucode"
+   timeout: 1200
  - "-rm /etc/calamares/scripts/remove-ucode"
 i18n:
  name: "Remove unneeded ucode"


### PR DESCRIPTION
someone reported that it was timing out what causing install to fail on uninstalling amd-ucode:
```

2025-08-06 - 22:35:23 [2]:     WARNING: Process "/bin/sh" timed out after 30000 ms. Output so far:
checking dependencies...

Package (1)  Old Version   Net Change

amd-ucode    1:20250708-2   -0.29 MiB

Total Removed Size:  0.29 MiB

:: Do you want to remove these packages? [Y/n] 
:: Processing package changes...
removing amd-ucode...

2025-08-06 - 22:35:23 [2]: WARNING (Qt): QProcess: Destroyed while process ("chroot") is still running.
```
