### PR TITLE
shellprocess: sdboot: Do not append fbcon to LINUX_OPTIONS

### DIFF
--- a/src/modules/netinstall/netinstall.yaml
+++ b/src/modules/netinstall/netinstall.yaml
@@ -226,7 +226,6 @@
     - kdeplasma-addons
     - ffmpegthumbs
     - kinfocenter
-    - kinit
     - kscreen
     - kwallet-pam
     - kwalletmanager

--- a/src/modules/shellprocess/shellprocess_enable_sdboot.conf
+++ b/src/modules/shellprocess/shellprocess_enable_sdboot.conf
@@ -9,7 +9,6 @@ timeout: 3600
 script:
     - "-rm -rf /boot/loader/entries/*"
     #\x22 corresponds to "
-    - "sed -i 's/LINUX_OPTIONS=[\x22][^\x22]*/& fbcon=vc:2-6/' /etc/sdboot-manage.conf"
     - command: "sdboot-manage gen"
       verbose: true
 


### PR DESCRIPTION
In cachyos-handheld package we have in-place an additional config that
adds the necessary parameters to the boot commandline based on each
device. The presence of this fbcon parameter completely negates that.
Remove this and hand it over to the additional config.