### PR TITLE
[Fonts] Remove adobe asian fonts and opendesktop fonts

### DIFF
--- a/src/modules/netinstall/netinstall.yaml
+++ b/src/modules/netinstall/netinstall.yaml
@@ -129,16 +129,12 @@
         description: "CachyOS font selection"
         selected: true
         packages:
-          - adobe-source-han-sans-cn-fonts
-          - adobe-source-han-sans-jp-fonts
-          - adobe-source-han-sans-kr-fonts
           - awesome-terminal-fonts
           - noto-fonts-emoji
           - noto-color-emoji-fontconfig
           - cantarell-fonts
           - freetype2
           - noto-fonts
-          - opendesktop-fonts
           - ttf-bitstream-vera
           - ttf-dejavu
           - ttf-liberation


### PR DESCRIPTION
The reason for this is that [noto-sans-cjk](https://github.com/notofonts/noto-cjk) covers everything and more than what adobe fonts do, opendesktop fonts are not necessary and take priority over noto-fonts-cjk on apps like Discord, making text pixelated when asian characters are used.

With noto-fonts-cjk taking priority this makes much more sense on desktop usage since most of desktop stuff is using noto-fonts already.

Edit: this change also affects all electron and chromium apps, giving them better looking fonts