### PR TITLE
displaymanager: Add support for plasmalogin and cosmic-greeter

### DIFF
--- a/src/modules/displaymanager/displaymanager.conf
+++ b/src/modules/displaymanager/displaymanager.conf
@@ -8,6 +8,7 @@
 # globalstorage (where it would come from the users page).
 ---
 displaymanagers:
+  - plasmalogin
   - sddm
   - lightdm
   - gdm

--- a/src/modules/displaymanager/displaymanager.conf
+++ b/src/modules/displaymanager/displaymanager.conf
@@ -12,6 +12,7 @@ displaymanagers:
   - sddm
   - lightdm
   - gdm
+  - cosmic-greeter
   - lxdm
 #  - greetd
 

--- a/src/modules/displaymanager/displaymanager.schema.yaml
+++ b/src/modules/displaymanager/displaymanager.schema.yaml
@@ -10,7 +10,7 @@ properties:
         type: array
         items:
             type: string
-            enum: [slim, sddm, lightdm, gdm, mdm, lxdm, greetd]
+            enum: [slim, plasmalogin, sddm, lightdm, gdm, mdm, lxdm, greetd]
         minItems: 1  # Must be non-empty, if present at all
     defaultDesktopEnvironment:
         type: object

--- a/src/modules/displaymanager/displaymanager.schema.yaml
+++ b/src/modules/displaymanager/displaymanager.schema.yaml
@@ -10,7 +10,7 @@ properties:
         type: array
         items:
             type: string
-            enum: [slim, plasmalogin, sddm, lightdm, gdm, mdm, lxdm, greetd]
+            enum: [slim, plasmalogin, sddm, lightdm, gdm, mdm, lxdm, greetd, cosmic-greeter]
         minItems: 1  # Must be non-empty, if present at all
     defaultDesktopEnvironment:
         type: object

--- a/src/modules/displaymanager/main.py
+++ b/src/modules/displaymanager/main.py
@@ -840,6 +840,42 @@ class DMplasmalogin(DisplayManager):
         pass
 
 
+class DMcosmicgreeter(DisplayManager):
+    name = "cosmic-greeter"
+    executable = "cosmic-greeter"
+    service_name = "cosmic-greeter.service"
+
+    def have_dm(self):
+        service_locations = [
+            os.path.join(self.root_mount_point, "usr/lib/systemd/system", self.service_name),
+            os.path.join(self.root_mount_point, "lib/systemd/system", self.service_name)
+        ]
+        if any(os.path.exists(path) for path in service_locations):
+            return True
+        return super().have_dm()
+
+    def basic_setup(self):
+        pass
+
+    def desktop_environment_setup(self, desktop_environment):
+        pass
+
+    def greeter_setup(self):
+        # cosmic-greeter only needs its systemd service enabled.
+        result = libcalamares.utils.target_env_call(
+            ["systemctl", "enable", self.service_name]
+        )
+        if result != 0:
+            return (
+                _("Cannot configure cosmic-greeter"),
+                _("Failed to enable {!s} (exit code {!s}).").format(self.service_name, result)
+            )
+
+    def set_autologin(self, username, do_autologin, default_desktop_environment):
+        if do_autologin:
+            libcalamares.utils.warning("cosmic-greeter does not support autologin; skipping autologin setup.")
+
+
 class DMgreetd(DisplayManager):
     name = "greetd"
     executable = "greetd"

--- a/src/modules/displaymanager/main.py
+++ b/src/modules/displaymanager/main.py
@@ -877,7 +877,7 @@ class DMcosmicgreeter(DisplayManager):
     def set_autologin(self, username, do_autologin, default_desktop_environment):
         if do_autologin:
             libcalamares.utils.warning("cosmic-greeter does not support autologin; skipping autologin setup.")
-
+        return super().set_autologin()
 
 class DMgreetd(DisplayManager):
     name = "greetd"

--- a/src/modules/displaymanager/main.py
+++ b/src/modules/displaymanager/main.py
@@ -792,6 +792,54 @@ class DMsddm(DisplayManager):
         pass
 
 
+class DMplasmalogin(DisplayManager):
+    name = "plasmalogin"
+    executable = "plasmalogin"
+    configuration_file = "/etc/plasmalogin.conf"
+
+    def set_autologin(self, username, do_autologin, default_desktop_environment):
+        import configparser
+
+        config_path = os.path.join(self.root_mount_point, self.configuration_file.lstrip('/'))
+
+        configuration = configparser.ConfigParser(strict=False)
+        configuration.optionxform = str
+
+        if os.path.isfile(config_path):
+            configuration.read(config_path)
+
+        if 'Autologin' not in configuration:
+            configuration.add_section('Autologin')
+
+        if do_autologin:
+            configuration.set('Autologin', 'User', username)
+        elif configuration.has_option('Autologin', 'User'):
+            configuration.remove_option('Autologin', 'User')
+
+        if default_desktop_environment is not None:
+            configuration.set(
+                'Autologin',
+                'Session',
+                default_desktop_environment.desktop_file
+                )
+
+        config_dir = os.path.dirname(config_path)
+        if config_dir and not os.path.isdir(config_dir):
+            os.makedirs(config_dir)
+
+        with open(config_path, 'w') as plasmalogin_config:
+            configuration.write(plasmalogin_config, space_around_delimiters=False)
+
+    def basic_setup(self):
+        pass
+
+    def desktop_environment_setup(self, desktop_environment):
+        pass
+
+    def greeter_setup(self):
+        pass
+
+
 class DMgreetd(DisplayManager):
     name = "greetd"
     executable = "greetd"

--- a/src/modules/displaymanager/main.py
+++ b/src/modules/displaymanager/main.py
@@ -806,7 +806,10 @@ class DMplasmalogin(DisplayManager):
         configuration.optionxform = str
 
         if os.path.isfile(config_path):
-            configuration.read(config_path)
+            try:
+                configuration.read(config_path)
+            except configparser.Error as error:
+                return (_("Failed to read plasmalogin config {!s}: {!s}").format(config_path, error))
 
         if 'Autologin' not in configuration:
             configuration.add_section('Autologin')


### PR DESCRIPTION
Prepare for upcoming change at KDE to default to plasmalogin instead of sddm


Cosmic-greeter support added. Cosmic Greeter does not support autologin and only requires to enable its service. Cosmic greeter uses greetd, but with its own service/config.