### PR TITLE
Add bluez-obex to netinstall packages list

### DIFF
--- a/src/modules/netinstall/netinstall.yaml
+++ b/src/modules/netinstall/netinstall.yaml
@@ -82,6 +82,7 @@
           - bluez
           - bluez-hid2hci
           - bluez-libs
+          - bluez-obex
           - bluez-utils
       - name: "packages management"
         description: "Packages tools"


### PR DESCRIPTION
This is required for file transfer and to support certain embedded buttons in Plasma.
Closes [issue #192](https://github.com/CachyOS/distribution/issues/192).