### PR TITLE
initcpiocfg: Disable systemd hook, when zfs or bcachefs is used

### DIFF
--- a/src/modules/initcpiocfg/main.py
+++ b/src/modules/initcpiocfg/main.py
@@ -104,6 +104,17 @@ def find_initcpio_features(partitions, root_mount_point):
     systemd_hook_allowed = libcalamares.job.configuration.get("useSystemdHook", False)
     is_zfs_native_encrypted = libcalamares.globalstorage.value("zfsEncrypted")
 
+    # Check if ZFS is used
+    uses_zfs = False
+    for partition in partitions:
+        if partition["fs"] == "zfs" and libcalamares.globalstorage.contains("zfsPoolInfo"):
+            uses_zfs = True
+            break
+
+    # Disable systemd hook if ZFS is used
+    if uses_zfs:
+        systemd_hook_allowed = False
+
     use_systemd = systemd_hook_allowed and target_env_call(["sh", "-c", "which systemd-cat"]) == 0
 
     if use_systemd:
@@ -129,7 +140,7 @@ def find_initcpio_features(partitions, root_mount_point):
 
     swap_uuid = ""
     uses_btrfs = False
-    uses_zfs = False
+    # uses_zfs is already initialized above
     uses_lvm2 = False
     encrypt_hook = False
     openswap_hook = False
@@ -152,9 +163,6 @@ def find_initcpio_features(partitions, root_mount_point):
         if partition["fs"] == "btrfs":
             uses_btrfs = True
 
-        # In addition to checking the filesystem, check to ensure that zfs is enabled
-        if partition["fs"] == "zfs" and libcalamares.globalstorage.contains("zfsPoolInfo"):
-            uses_zfs = True
 
         if "lvm2" in partition["fs"]:
             uses_lvm2 = True

--- a/src/modules/initcpiocfg/main.py
+++ b/src/modules/initcpiocfg/main.py
@@ -104,15 +104,18 @@ def find_initcpio_features(partitions, root_mount_point):
     systemd_hook_allowed = libcalamares.job.configuration.get("useSystemdHook", False)
     is_zfs_native_encrypted = libcalamares.globalstorage.value("zfsEncrypted")
 
-    # Check if ZFS is used
+    # Check if ZFS or bcachefs is used
     uses_zfs = False
+    uses_bcachefs = False
     for partition in partitions:
         if partition["fs"] == "zfs" and libcalamares.globalstorage.contains("zfsPoolInfo"):
             uses_zfs = True
-            break
 
-    # Disable systemd hook if ZFS is used
-    if uses_zfs:
+        if partition["fs"] == "bcachefs":
+            uses_bcachefs = True
+
+    # Disable systemd hook if ZFS or bcachefs is used
+    if uses_zfs or uses_bcachefs:
         systemd_hook_allowed = False
 
     use_systemd = systemd_hook_allowed and target_env_call(["sh", "-c", "which systemd-cat"]) == 0


### PR DESCRIPTION
Tested ZFS non encrypted install. Hooks are correctly passed

bcachefs untested