### PR TITLE
Cleaned up OOBE Gnome (Grub)

### DIFF
--- a/src/modules/netinstall/netinstall.yaml
+++ b/src/modules/netinstall/netinstall.yaml
@@ -264,12 +264,9 @@
   critical: true
   packages:
     - adwaita-icon-theme
-    - eog
-    - evince
     - file-roller
     - fwupd
     - gdm
-    - gedit
     - gnome
     - gnome-backgrounds
     - gnome-calculator
@@ -278,12 +275,9 @@
     - gnome-keyring
     - gnome-nettool
     - gnome-power-manager
-    - gnome-screenshot
     - gnome-shell
-    - gnome-terminal
     - gnome-themes-extra
     - gnome-tweaks
-    - gnome-usage
     - malcontent
     - libnma
     - gvfs
@@ -294,7 +288,6 @@
     - gvfs-smb
     - nautilus
     - sushi
-    - totem
     - qt6-wayland
     - xdg-user-dirs-gtk
     - xdg-desktop-portal-gnome


### PR DESCRIPTION
Issue: https://github.com/CachyOS/cachyos-calamares/issues/101

How it was solved: I went by what was said in martinpl's reply. Cachy with Gnome OOBE should be cleaner.

The problems I faced: The Github app was confusing with how branches are handled, so I had to do these changes in the browser. I'm learning as I go, I'm new to all this.