### PR TITLE
Add dolphin-plugins, okular, plasma-disks, plasma-vault to KDE (Grub)

### DIFF
--- a/src/modules/netinstall/netinstall.yaml
+++ b/src/modules/netinstall/netinstall.yaml
@@ -218,6 +218,7 @@
     - cachyos-themes-sddm
     - char-white
     - dolphin
+    - dolphin-plugins
     - egl-wayland
     - ffmpegthumbs
     - filelight
@@ -238,15 +239,18 @@
     - kwallet-pam
     - kwalletmanager
     - libplasma
+    - okular
     - phonon-qt6-vlc
     - plasma-browser-integration
     - plasma-desktop
+    - plasma-disks
     - plasma-firewall
     - plasma-integration
     - plasma-nm
     - plasma-pa
     - plasma-systemmonitor
     - plasma-thunderbolt
+    - plasma-vault
     - plasma-workspace
     - plymouth-kcm
     - powerdevil


### PR DESCRIPTION
dolphin-plugins: These plugins integrate revision control systems, dropbox and adds a mount or unmount action for iso's.

okular: The Universal Document Viewer.

plasma-disks: Monitors S.M.A.R.T. capable devices for imminent failure.

plasma-vault: Plasma applet and services for creating encrypted vaults.

(Would do Deckify but I don't know if that wants to be as minimal as possible)