### PR TITLE
Pacstrap: pick architecture earlier and use --sysroot

### DIFF
--- a/settings_online.conf
+++ b/settings_online.conf
@@ -60,13 +60,13 @@ sequence:
   - mount
   - shellprocess@modify_mk_hook
   - shellprocess@initialize_pacman
+  - shellprocess@before-online
   - pacstrap
   - machineid
   - locale
   - keyboard
   - localecfg
   - chwd
-  - shellprocess@before-online
   - packages@online
   - luksbootkeyfile
   - luksopenswaphookcfg

--- a/src/modules/pacstrap/pacstrap.conf
+++ b/src/modules/pacstrap/pacstrap.conf
@@ -69,12 +69,9 @@ basePackages:
 # location in the installed system
 #
 postInstallFiles:
-  - "/etc/pacman.conf"
-  - "/etc/pacman-more.conf"
   - "/etc/mkinitcpio.conf"
   - "/usr/local/bin/dmcheck"
   - "/usr/local/bin/remove-nvidia"
-  - "/etc/calamares/scripts/try-v3"
   - "/etc/calamares/scripts/remove-ucode"
   - "/etc/calamares/scripts/enable-ufw"
   - "/etc/calamares/scripts/limine-snapper-sync-setup"

--- a/src/modules/shellprocess/shellprocess-before-online.conf
+++ b/src/modules/shellprocess/shellprocess-before-online.conf
@@ -37,8 +37,8 @@ i18n:
      name[es]: "Preparación de su sistema para la instalación en línea de CachyOS"
      name[ru]: "Подготовка вашей системы к онлайн установке CachyOS"
 
-dontChroot: false
-timeout: 3600
+dontChroot: true
+timeout: 10
 script:
-    - command: "/etc/calamares/scripts/try-v3"
-    - "-rm /etc/calamares/scripts/try-v3"
+    - command: "/etc/calamares/scripts/detect-architecture"
+    - command: "cp /etc/pacman-target.conf ${ROOT}/etc/pacman.conf"

--- a/src/scripts/detect-architecture
+++ b/src/scripts/detect-architecture
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+## Copied & renamed from src/scripts/try-v3
+## Detect machine architecture, pick corresponding CachyOS optimized repositories, create /etc/pacman-target.conf
+## This is supposed to run on live system w/o chroot.
+
+# Pacman Files
+pacman_conf="/etc/pacman.conf"
+pacman_conf_cachyos="/etc/pacman-more.conf"
+pacman_conf_path_backup="${pacman_conf}.bak"
+
+# Architecture Check
+check_v3="$(/lib/ld-linux-x86-64.so.2 --help | grep 'x86-64-v3 (' | awk '{print $1}')"
+check_v4="$(/lib/ld-linux-x86-64.so.2 --help | grep 'x86-64-v4 (' | awk '{print $1}')"
+check_znver4_znver5="$(gcc -march=native -Q --help=target 2>&1 | head -n 37 | grep -E '(znver4|znver5)')"
+
+if [ -n "$check_znver4_znver5" ]; then
+  echo "znver4 or znver5 is supported"
+  sed -i 's/#<disabled_znver4>//g' $pacman_conf_cachyos
+  sed -i '/disabled_v[34]/d' $pacman_conf_cachyos
+  echo "backup old config"
+  mv $pacman_conf $pacman_conf_path_backup
+  echo "CachyOS -znver4 Repo changed"
+  mv $pacman_conf_cachyos $pacman_conf
+elif [ "$check_v4" == "x86-64-v4" ]; then
+  echo "x86-64-v4 is supported"
+  sed -i 's/#<disabled_v4>//g' $pacman_conf_cachyos
+  sed -i '/disabled_v3/d' $pacman_conf_cachyos
+  sed -i '/disabled_znver4/d' $pacman_conf_cachyos
+  echo "backup old config"
+  mv $pacman_conf $pacman_conf_path_backup
+  echo "CachyOS -v4 Repo changed"
+  mv $pacman_conf_cachyos $pacman_conf
+elif [ "$check_v3" == "x86-64-v3" ]; then
+  echo "x86-64-v3 is supported"
+  sed -i 's/#<disabled_v3>//g' $pacman_conf_cachyos
+  sed -i '/disabled_znver4/d' $pacman_conf_cachyos
+  sed -i '/disabled_v4/d' $pacman_conf_cachyos
+  echo "backup old config"
+  mv $pacman_conf $pacman_conf_path_backup
+  echo "CachyOS -v3 Repo changed"
+  mv $pacman_conf_cachyos $pacman_conf
+else
+  echo "x86-64-v4 and x86-64 is not supported"
+  echo "backup old config"
+  mv $pacman_conf $pacman_conf_path_backup
+  echo "CachyOS Repo changed"
+  mv $pacman_conf_cachyos $pacman_conf
+fi

--- a/src/scripts/detect-architecture
+++ b/src/scripts/detect-architecture
@@ -5,9 +5,9 @@
 ## This is supposed to run on live system w/o chroot.
 
 # Pacman Files
-pacman_conf="/etc/pacman.conf"
+pacman_conf_live=/etc/pacman.conf
 pacman_conf_cachyos="/etc/pacman-more.conf"
-pacman_conf_path_backup="${pacman_conf}.bak"
+pacman_conf_target=/etc/pacman-target.conf
 
 # Architecture Check
 check_v3="$(/lib/ld-linux-x86-64.so.2 --help | grep 'x86-64-v3 (' | awk '{print $1}')"
@@ -15,35 +15,28 @@ check_v4="$(/lib/ld-linux-x86-64.so.2 --help | grep 'x86-64-v4 (' | awk '{print 
 check_znver4_znver5="$(gcc -march=native -Q --help=target 2>&1 | head -n 37 | grep -E '(znver4|znver5)')"
 
 if [ -n "$check_znver4_znver5" ]; then
-  echo "znver4 or znver5 is supported"
-  sed -i 's/#<disabled_znver4>//g' $pacman_conf_cachyos
-  sed -i '/disabled_v[34]/d' $pacman_conf_cachyos
-  echo "backup old config"
-  mv $pacman_conf $pacman_conf_path_backup
-  echo "CachyOS -znver4 Repo changed"
-  mv $pacman_conf_cachyos $pacman_conf
+  echo "znver4 or znver5 is supported (but we only have znver4
+  available)"
+  sed -e 's/#<disabled_znver4>//g' \
+    -e '/disabled_v[34]/d' $pacman_conf_cachyos \
+    > $pacman_conf_target
 elif [ "$check_v4" == "x86-64-v4" ]; then
   echo "x86-64-v4 is supported"
-  sed -i 's/#<disabled_v4>//g' $pacman_conf_cachyos
-  sed -i '/disabled_v3/d' $pacman_conf_cachyos
-  sed -i '/disabled_znver4/d' $pacman_conf_cachyos
-  echo "backup old config"
-  mv $pacman_conf $pacman_conf_path_backup
-  echo "CachyOS -v4 Repo changed"
-  mv $pacman_conf_cachyos $pacman_conf
+  sed -e 's/#<disabled_v4>//g' \
+    -e '/disabled_v3/d' \
+    -e '/disabled_znver4/d' $pacman_conf_cachyos \
+    > $pacman_conf_target
 elif [ "$check_v3" == "x86-64-v3" ]; then
   echo "x86-64-v3 is supported"
-  sed -i 's/#<disabled_v3>//g' $pacman_conf_cachyos
-  sed -i '/disabled_znver4/d' $pacman_conf_cachyos
-  sed -i '/disabled_v4/d' $pacman_conf_cachyos
-  echo "backup old config"
-  mv $pacman_conf $pacman_conf_path_backup
-  echo "CachyOS -v3 Repo changed"
-  mv $pacman_conf_cachyos $pacman_conf
+  sed -e 's/#<disabled_v3>//g' \
+    -e '/disabled_znver4/d' \
+    -e '/disabled_v4/d' $pacman_conf_cachyos \
+    > $pacman_conf_target
 else
-  echo "x86-64-v4 and x86-64 is not supported"
-  echo "backup old config"
-  mv $pacman_conf $pacman_conf_path_backup
-  echo "CachyOS Repo changed"
-  mv $pacman_conf_cachyos $pacman_conf
+  echo "Legacy hardware assumed"
+  # Assuming that Live OS needs to run on unoptimized x86_64 repo
+  # for compatibility
+  cp $pacman_conf_live $pacman_conf_target
 fi
+
+echo Repo configured in /etc/pacman-target.conf

--- a/src/scripts/pacstrap_calamares
+++ b/src/scripts/pacstrap_calamares
@@ -353,7 +353,7 @@ chroot_setup "$newroot" || die "failed to setup chroot %s" "$newroot"
 
 
 msg 'Installing packages to %s' "$newroot"
-if ! pacman -r "$newroot" -Sy "${pacman_args[@]}"; then
+if ! pacman --sysroot "$newroot" -Sy "${pacman_args[@]}"; then
   die 'Failed to install packages to new root'
 fi
 

--- a/src/scripts/try-v3
+++ b/src/scripts/try-v3
@@ -18,7 +18,7 @@ if [ -n "$check_znver4_znver5" ]; then
   mv $pacman_conf $pacman_conf_path_backup
   echo "CachyOS -znver4 Repo changed"
   mv $pacman_conf_cachyos $pacman_conf
-elif [ $check_v4 == "x86-64-v4" ]; then
+elif [ "$check_v4" == "x86-64-v4" ]; then
   echo "x86-64-v4 is supported"
   sed -i 's/#<disabled_v4>//g' $pacman_conf_cachyos
   sed -i '/disabled_v3/d' $pacman_conf_cachyos
@@ -27,7 +27,7 @@ elif [ $check_v4 == "x86-64-v4" ]; then
   mv $pacman_conf $pacman_conf_path_backup
   echo "CachyOS -v4 Repo changed"
   mv $pacman_conf_cachyos $pacman_conf
-elif [ $check_v3 == "x86-64-v3" ]; then
+elif [ "$check_v3" == "x86-64-v3" ]; then
   echo "x86-64-v3 is supported"
   sed -i 's/#<disabled_v3>//g' $pacman_conf_cachyos
   sed -i '/disabled_znver4/d' $pacman_conf_cachyos


### PR DESCRIPTION
# Problems

It started with this [quote]:

> It doesn't use live ISO pacman cache. Only target OS cache

## Wrong Cache

This turns out to be not true when I'm testing in a QEMU VM (see `Some Numbers` below). This can be problematic because:

- Those packages will not be available for downgrade post-install -- not a big thing though.
- Live OS runs on squashfs + overlay. Those packages are stored in overlay FS backed by tmpfs `/run/archiso/cowspace` which costs RAM. On my 8GB VM this puts a lot of extra pressure on RAM, triggering more swapping to zram, slowing down testing quite a bit if I want to use Firefox.
  * And I'm quite curious if [3GB of RAM as the minimum spec][cachy wiki] would actually work.

## Running Hooks / Scripts for the Wrong OS

Where do pacman hooks / post-install scripts run without `chroot`-ing into the target OS? I believe they are running on live OS, leaving target OS in a potentially broken state.

Good news is, this is likely already mitigated by some later step(s) of the installer. Otherwise it'll be hell-on-earth in Discord `#support`.

## Repeated Installation

Another problem is: all the packages downloaded onto live OS are of `x86_64` architecture. Later the installer will upgrade some of them to their optimized version for target OS. Those packages will be downloaded & installed twice, costing time and Internet traffic.

Turns out, the pacstrap step is using `/etc/pacman.conf` from live OS with no optimized repositories configured.

# Solution

This patch does the following:

* Run `shellprocess@before-online` earlier in the install process to detect architecture & setup optimized repo
* Use `--sysroot` instead of `--root` for pacman in the pacstrap step

## Some Numbers

A typical Limine - Btrfs - KDE install costs: (ISO version 251129)
* 1.6GB in `/var/cache/packman/pkg` on Live OS 
* 2.4GB in `@cache/pacman/pkg` on target OS.

On my local integration branch with all my recent patches merged:
* Less than 1MB of cache on live
* 2.8GB on target

We can avoid installing 1.2GB of packages.

[Quote]: https://github.com/CachyOS/cachyos-calamares/pull/124#issuecomment-3621965326
[cachy wiki]: https://wiki.cachyos.org/installation/installation_prepare/