### PR TITLE
netinstall: Install essential handheld packages by default

### DIFF
--- a/src/modules/netinstall/netinstall.yaml
+++ b/src/modules/netinstall/netinstall.yaml
@@ -13,6 +13,9 @@
      - linux-cachyos-deckify
      - linux-cachyos-deckify-headers
      - chwd
+     - inputplumber
+     - steamos-manager
+     - steamos-powerbuttond
 - name: "CachyOS Packages"
   description: "needed CachyOS packages"
   hidden: false


### PR DESCRIPTION
Include inputplumber, steamos-manager and steamos-powerbuttond as base and essential packages for the handheld edition.

These packages are installed from here instead of it being a dependency of `cachyos-handheld` or creating yet another meta package is because users may opt to use HHD instead of the inputplumber family.

This will also help devices that are not supported by chwd work better OOTB by preinstalling the packages required for basic functionality.