### PR TITLE
Fix Calamares installation failure: Replace vlc-plugins-all with vlc

### DIFF
--- a/src/modules/netinstall/netinstall.yaml
+++ b/src/modules/netinstall/netinstall.yaml
@@ -109,7 +109,7 @@
           - libopenraw
           - mlocate
           - poppler-glib
-          - vlc-plugins-all
+          - vlc
           - xdg-user-dirs
           - xdg-utils
       - name: "filesystem"


### PR DESCRIPTION
## Issue

Calamares installation fails during the package installation phase with a "Package Manager error" due to a dependency version conflict in the GStreamer package ecosystem.

## Root Cause

The `vlc-plugins-all` package pulls in a dependency chain that causes version conflicts:
- `vlc-plugins-all` → `vlc-plugin-gstreamer` → `gst-plugin-va`
- `gst-plugin-va` requires exact versions:
  - `gstreamer=1.26.10-3`
  - `gst-plugins-base-libs=1.26.10-3`
  - `gst-plugins-bad-libs=1.26.10-3`
- During installation, pacman attempts to install version `1.26.10-2.1` of these packages
- This version mismatch causes: `error: failed to prepare transaction (could not satisfy dependencies)`

## Solution

Replace `vlc-plugins-all` with `vlc` in the desktop integration package group.

**Rationale:**
- `vlc` package does not pull in `gst-plugin-va` as a dependency
- This eliminates the version conflict entirely
- VLC media player will still be installed, just without all optional plugins
- Users can install `vlc-plugins-all` manually post-installation if needed

## Changes

- Modified: `src/modules/netinstall/netinstall.yaml` (line 112)
  - Changed: `- vlc-plugins-all` → `- vlc`

## Testing

This fix has been tested and resolves the installation failure. Calamares installations now proceed successfully past the package installation phase.