### PR TITLE
partition: validate EFI system partition size in ChoicePage

### DIFF
--- a/src/modules/partition/gui/ChoicePage.cpp
+++ b/src/modules/partition/gui/ChoicePage.cpp
@@ -1253,7 +1253,7 @@ ChoicePage::setupEfiSystemPartitionSelector()
         if ( !PartUtils::isEfiFilesystemRecommendedSize( efiPartition ) )
         {
             text += QStringLiteral( "<br/><font color=\"red\">" )
-                    + tr( "The EFI system partition is too small." )
+                    + tr( "The EFI system partition is too small, please use manual partition." )
                     + QStringLiteral( "</font>" );
         }
         m_efiLabel->setText( text );

--- a/src/modules/partition/gui/ChoicePage.cpp
+++ b/src/modules/partition/gui/ChoicePage.cpp
@@ -1243,16 +1243,47 @@ ChoicePage::setupEfiSystemPartitionSelector()
     }
     else if ( efiSystemPartitions.count() == 1 )  //probably most usual situation
     {
-        m_efiLabel->setText( tr( "The EFI system partition at %1 will be used for "
-                                 "starting %2.",
-                                 "@info, %1 is partition path, %2 is product name" )
-                                 .arg( efiSystemPartitions.first()->partitionPath() )
-                                 .arg( Calamares::Branding::instance()->shortProductName() ) );
+        Partition* efiPartition = efiSystemPartitions.first();
+        QString text = tr( "The EFI system partition at %1 will be used for "
+                           "starting %2.",
+                           "@info, %1 is partition path, %2 is product name" )
+                           .arg( efiPartition->partitionPath() )
+                           .arg( Calamares::Branding::instance()->shortProductName() );
+
+        if ( !PartUtils::isEfiFilesystemRecommendedSize( efiPartition ) )
+        {
+            text += QStringLiteral( "<br/><font color=\"red\">" )
+                    + tr( "The EFI system partition is too small." )
+                    + QStringLiteral( "</font>" );
+        }
+        m_efiLabel->setText( text );
     }
     else
     {
         m_efiComboBox->show();
-        m_efiLabel->setText( tr( "EFI system partition:", "@label" ) );
+
+        auto updateLabel = [ this, efiSystemPartitions ]( int index )
+        {
+            if ( index >= 0 && index < efiSystemPartitions.count() )
+            {
+                Partition* efiPartition = efiSystemPartitions.at( index );
+                QString text = tr( "EFI system partition:", "@label" );
+                if ( !PartUtils::isEfiFilesystemRecommendedSize( efiPartition ) )
+                {
+                    text += QStringLiteral( "<br/><font color=\"red\">" )
+                            + tr( "The EFI system partition is too small." )
+                            + QStringLiteral( "</font>" );
+                }
+                m_efiLabel->setText( text );
+            }
+            updateNextEnabled();
+        };
+
+        connect( m_efiComboBox,
+                 QOverload< int >::of( &QComboBox::currentIndexChanged ),
+                 this,
+                 updateLabel );
+
         for ( int i = 0; i < efiSystemPartitions.count(); ++i )
         {
             Partition* efiPartition = efiSystemPartitions.at( i );
@@ -1264,6 +1295,9 @@ ChoicePage::setupEfiSystemPartitionSelector()
                 m_efiComboBox->setCurrentIndex( i );
             }
         }
+
+        // Initialize label
+        updateLabel( m_efiComboBox->currentIndex() );
     }
 }
 
@@ -1540,9 +1574,30 @@ ChoicePage::calculateNextEnabled() const
          && ( m_config->installChoice() == InstallChoice::Alongside
               || m_config->installChoice() == InstallChoice::Replace ) )
     {
-        if ( m_core->efiSystemPartitions().count() == 0 )
+        QList< Partition* > efiSystemPartitions = m_core->efiSystemPartitions();
+        if ( efiSystemPartitions.count() == 0 )
         {
             cDebug() << "No EFI partition for alongside or replace";
+            return false;
+        }
+
+        Partition* efiPartition = nullptr;
+        if ( efiSystemPartitions.count() == 1 )
+        {
+            efiPartition = efiSystemPartitions.first();
+        }
+        else if ( m_efiComboBox && m_efiComboBox->isVisible() )
+        {
+            int index = m_efiComboBox->currentIndex();
+            if ( index >= 0 && index < efiSystemPartitions.count() )
+            {
+                efiPartition = efiSystemPartitions.at( index );
+            }
+        }
+
+        if ( efiPartition && !PartUtils::isEfiFilesystemRecommendedSize( efiPartition ) )
+        {
+            cDebug() << "Selected EFI partition is too small";
             return false;
         }
     }


### PR DESCRIPTION
This adds a check when "Replace Partition" or "Install Alongside" is used if the EFI Partition is big enough.

We are generally getting **a lot of reports** because people using this option and its reusing the Windows EFI partition and then results all time into a failed installation.

The images below are with a CachyOS Installation and grub, which uses a 500MB EFI size. After this installation ive patched calamares and selected "Limine", which needs 2GB size.

The installer is then blocking to go further and gives a warning in red. This should block most of the problems people reporting with this.

<img width="1660" height="864" alt="image" src="https://github.com/user-attachments/assets/d66c0bbe-fdf0-424b-be39-77694ab680a4" />
<img width="1643" height="880" alt="image" src="https://github.com/user-attachments/assets/6b1922b7-b68b-455d-a8ce-6f40efc33951" />

Fixes: https://github.com/CachyOS/cachyos-calamares/issues/91
Fixes: https://github.com/CachyOS/cachyos-calamares/issues/50
Fixes: https://github.com/CachyOS/cachyos-calamares/issues/86