### PR TITLE
netinstall: Add pipewire-jack

### DIFF
--- a/src/modules/netinstall/netinstall.yaml
+++ b/src/modules/netinstall/netinstall.yaml
@@ -150,9 +150,10 @@
           - alsa-plugins
           - alsa-utils
           - pavucontrol
-          - pipewire-pulse
           - wireplumber
+          - pipewire-pulse
           - pipewire-alsa
+          - pipewire-jack
           - rtkit
       - name: "hardware"
         description: "Hardware support libs and firmware"


### PR DESCRIPTION
By installing pipewire-jack by default, the system provides native jack support through pipewire, making a standalone jack installation unnecessary. 
This ensures that audio applications work out-of-the-box with low latency without any manual configuration or bridging.