### PR TITLE
netinstall: Clean up base packages group (Part 1)

### DIFF
--- a/src/modules/netinstall/netinstall.yaml
+++ b/src/modules/netinstall/netinstall.yaml
@@ -46,7 +46,6 @@
         packages:
            - libwnck3
            - mesa-utils
-           - xf86-input-libinput
            - xorg-xdpyinfo
            - xorg-server
            - xorg-xinit
@@ -57,7 +56,6 @@
         description: "Network apps drivers and tools"
         selected: true
         packages:
-          - dhclient
           - dnsmasq
           - dnsutils
           - ethtool
@@ -118,23 +116,18 @@
         selected: true
         packages:
           - efitools
-          - haveged
           - nfs-utils
           - nilfs-utils
-          - ntp
           - smartmontools
           - unrar
           - unzip
-          - xz
       - name: "fonts"
         description: "CachyOS font selection"
         selected: true
         packages:
           - awesome-terminal-fonts
           - noto-fonts-emoji
-          - noto-color-emoji-fontconfig
           - cantarell-fonts
-          - freetype2
           - noto-fonts
           - ttf-bitstream-vera
           - ttf-dejavu
@@ -153,7 +146,6 @@
           - pipewire-pulse
           - wireplumber
           - pipewire-alsa
-          - rtkit
       - name: "hardware"
         description: "Hardware support libs and firmware"
         selected: true
@@ -181,12 +173,10 @@
           - alacritty
           - btop
           - duf
-          - findutils
           - fsarchiver
           - git
           - glances
           - hwinfo
-          - inxi
           - meld
           - nano-syntax-highlighting
           - fastfetch
@@ -194,7 +184,6 @@
           - python-defusedxml
           - python-packaging
           - rsync
-          - sed
           - vi
           - wget
           - ripgrep


### PR DESCRIPTION
- sed: dependency of base package
- findutils: dependency of base package
- xz: dependency of base package
- xf86-input-libinput: dependency of xorg-server
- haveged: no longer needed 
- ntp: timesyncd should be used instead
- freetype2: general dependency for all applications
- rtkit: not used, considered obsolete
- inxi: dependency of cachyos-settings
- dhclient: considered outdated and unsupported
- noto-color-emoji-fontconfig: AUR package, seems to be no longer needed