### PR TITLE
netinstall: Replace mlocate with plocate

### DIFF
--- a/src/modules/netinstall/netinstall.yaml
+++ b/src/modules/netinstall/netinstall.yaml
@@ -108,7 +108,7 @@
           - libdvdcss
           - libgsf
           - libopenraw
-          - mlocate
+          - plocate
           - poppler-glib
           - vlc-plugins-all
           - xdg-user-dirs


### PR DESCRIPTION
mlocate is not in the repos. This switches to plocate, which is the official replacement and offers significantly better performance.