### PR TITLE
packagechooser: fix netinstall selection accumulation on revisit

### DIFF
--- a/src/modules/netinstall/NetInstallPage.cpp
+++ b/src/modules/netinstall/NetInstallPage.cpp
@@ -70,10 +70,21 @@ NetInstallPage::onActivate()
     // The netinstallSelect global storage value can be used to make additional items selected by default
     Calamares::GlobalStorage* gs = Calamares::JobQueue::instance()->globalStorage();
     const QStringList selectNames = gs->value( "netinstallSelect" ).toStringList();
-    if ( !selectNames.isEmpty() )
+
+    QStringList toUnselect;
+    for ( const auto& name : m_alreadySelected )
     {
-        m_config->model()->setSelections( selectNames );
+        if ( !selectNames.contains( name ) )
+        {
+            toUnselect.append( name );
+        }
     }
+
+    if ( !selectNames.isEmpty() || !toUnselect.isEmpty() )
+    {
+        m_config->model()->updateSelections( selectNames, toUnselect );
+    }
+    m_alreadySelected = selectNames;
 
     // If NetInstallAdd is found in global storage, add those items to the tree
     const QVariantList groups = gs->value( "netinstallAdd" ).toList();

--- a/src/modules/netinstall/NetInstallPage.h
+++ b/src/modules/netinstall/NetInstallPage.h
@@ -48,6 +48,7 @@ public:
     void expandGroups();
 
 private:
+    QStringList m_alreadySelected;
     Config* m_config;
     Ui::Page_NetInst* ui;
 };

--- a/src/modules/netinstall/PackageModel.cpp
+++ b/src/modules/netinstall/PackageModel.cpp
@@ -28,17 +28,30 @@ static bool gShowConfError{};
 
 /// Recursive helper for setSelections()
 static void
-setSelections( const QStringList& selectNames, PackageTreeItem* item )
+updateSelections( const QStringList& selectNames, const QStringList& unselectNames, PackageTreeItem* item )
 {
     for ( int i = 0; i < item->childCount(); i++ )
     {
         auto* child = item->child( i );
-        setSelections( selectNames, child );
+        updateSelections( selectNames, unselectNames, child );
     }
-    if ( item->isGroup() && selectNames.contains( item->name() ) )
+    if ( item->isGroup() )
     {
-        item->setSelected( Qt::CheckState::Checked );
+        if ( selectNames.contains( item->name() ) )
+        {
+            item->setSelected( Qt::CheckState::Checked );
+        }
+        else if ( unselectNames.contains( item->name() ) )
+        {
+            item->setSelected( Qt::CheckState::Unchecked );
+        }
     }
+}
+
+static void
+setSelections( const QStringList& selectNames, PackageTreeItem* item )
+{
+    updateSelections( selectNames, {}, item );
 }
 
 /** @brief Collects all the "source" values from @p groupList
@@ -296,6 +309,15 @@ PackageModel::setSelections( const QStringList& selectNames )
     if ( m_rootItem )
     {
         ::setSelections( selectNames, m_rootItem );
+    }
+}
+
+void
+PackageModel::updateSelections( const QStringList& selectNames, const QStringList& unselectNames )
+{
+    if ( m_rootItem )
+    {
+        ::updateSelections( selectNames, unselectNames, m_rootItem );
     }
 }
 

--- a/src/modules/netinstall/PackageModel.h
+++ b/src/modules/netinstall/PackageModel.h
@@ -67,6 +67,15 @@ public:
      */
     void setSelections( const QStringList& selectNames );
 
+    /** @brief Sets and unsets the checked flag on matching groups in the tree
+     *
+     * Recursively traverses the tree pointed to by m_rootItem.
+     * If a group name matches any of the items in @p selectNames, it is checked.
+     * If a group name matches any of the items in @p unselectNames, it is unchecked.
+     *
+     */
+    void updateSelections( const QStringList& selectNames, const QStringList& unselectNames );
+
     PackageTreeItem::List getPackages() const;
     PackageTreeItem::List getItemPackages( PackageTreeItem* item ) const;
 

--- a/src/modules/netinstall/Tests.cpp
+++ b/src/modules/netinstall/Tests.cpp
@@ -43,6 +43,7 @@ private Q_SLOTS:
     void testGroup();
     void testCompare();
     void testModel();
+    void testUpdateSelections();
     void testExampleFiles();
 
     void testUrlFallback_data();
@@ -304,6 +305,30 @@ ItemTests::testModel()
 
     // But m2 has "expanded" set which the others do no
     QVERIFY( *( m2.m_rootItem->child( 0 ) ) != *group );
+}
+
+void
+ItemTests::testUpdateSelections()
+{
+    auto yamldoc = ::YAML::Load( doc );
+    QVariantList yamlContents = Calamares::YAML::sequenceToVariant( yamldoc );
+
+    PackageModel m( nullptr );
+    m.setupModelData( yamlContents );
+
+    // Verify initial state
+    QCOMPARE( m.m_rootItem->childCount(), 1 );
+    PackageTreeItem* group = m.m_rootItem->child( 0 );
+    QCOMPARE( group->name(), QStringLiteral( "CCR" ) );
+    QCOMPARE( group->isSelected(), Qt::Checked );
+
+    // Test unselecting
+    m.updateSelections( {}, { "CCR" } );
+    QCOMPARE( group->isSelected(), Qt::Unchecked );
+
+    // Test selecting back
+    m.updateSelections( { "CCR" }, {} );
+    QCOMPARE( group->isSelected(), Qt::Checked );
 }
 
 void

--- a/src/modules/packagechooser/Config.cpp
+++ b/src/modules/packagechooser/Config.cpp
@@ -168,24 +168,35 @@ Config::updateGlobalStorage( const QStringList& selected ) const
     else if ( m_method == PackageChooserMethod::NetSelect )
     {
         cDebug() << m_defaultId << "groups to select in netinstall" << selected;
-        QStringList newSelected = selected;
         auto* gs = Calamares::JobQueue::instance()->globalStorage();
 
-        // If an earlier packagechooser instance added this data to global storage, combine them
+        QStringList currentNetinstallSelect;
         if ( gs->contains( "netinstallSelect" ) )
         {
-            auto selectedOrig = gs->value( "netinstallSelect" );
-            if ( selectedOrig.canConvert< QStringList >() )
+            auto val = gs->value( "netinstallSelect" );
+            if ( val.canConvert< QStringList >() )
             {
-                newSelected += selectedOrig.toStringList();
+                currentNetinstallSelect = val.toStringList();
             }
             else
             {
-                cWarning() << "Invalid NetinstallSelect data in global storage.  Earlier selections purged";
+                cWarning() << "Invalid NetinstallSelect data in global storage. Resetting.";
             }
-            gs->remove( "netinstallSelect" );
         }
-        gs->insert( "netinstallSelect", newSelected );
+
+        const QString previousSelectionKey = QStringLiteral( "packagechooser_previous_selection_" ) + m_defaultId.id();
+        if ( gs->contains( previousSelectionKey ) )
+        {
+            const QStringList previousSelection = gs->value( previousSelectionKey ).toStringList();
+            for ( const auto& item : previousSelection )
+            {
+                currentNetinstallSelect.removeOne( item );
+            }
+        }
+
+        currentNetinstallSelect += selected;
+        gs->insert( "netinstallSelect", currentNetinstallSelect );
+        gs->insert( previousSelectionKey, selected );
     }
     else
     {


### PR DESCRIPTION
Fixes when choosing packagechooser@desktop a desktop env, go forward, and go back and then select different one to be both selected

Full testing pending