### PR TITLE
mount: Use single-level compression on NVMe for Btrfs 

### DIFF
--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -113,7 +113,11 @@ def get_mount_options(filesystem, mount_options, partition, efi_location = None)
 
     # Append the appropriate options for ssd or hdd if set
     if is_ssd_disk(partition):
-        option_items.extend(options.get("ssdOptions", []))
+        name = os.path.basename(partition["device"])
+        if name.startswith("/dev/nvme"):
+            option_items.extend(options.get("nvmeOptions", []))
+        else:
+            option_items.extend(options.get("ssdOptions", []))
     else:
         option_items.extend(options.get("hddOptions", []))
 

--- a/src/modules/mount/mount.conf
+++ b/src/modules/mount/mount.conf
@@ -50,7 +50,10 @@ mountOptions:
     - filesystem: efi
       options: [ defaults, umask=0077 ]
     - filesystem: btrfs
-      options: [ defaults, noatime, compress=zstd, commit=120 ]
+      hddOptions: [ compress=zstd ]
+      ssdOptions: [ compress=zstd ]
+      nvmeOptions: [ compress=zstd:1 ]
+      options: [ defaults, noatime, commit=120 ]
     - filesystem: btrfs_swap
       options: [ defaults, noatime ]
     - filesystem: ext4

--- a/src/modules/mount/mount.conf
+++ b/src/modules/mount/mount.conf
@@ -53,11 +53,11 @@ mountOptions:
       hddOptions: [ compress=zstd ]
       ssdOptions: [ compress=zstd ]
       nvmeOptions: [ compress=zstd:1 ]
-      options: [ defaults, noatime, commit=120 ]
+      options: [ defaults, noatime ]
     - filesystem: btrfs_swap
       options: [ defaults, noatime ]
     - filesystem: ext4
-      options: [ defaults, noatime, commit=60 ]
+      options: [ defaults, noatime ]
     - filesystem: xfs
       options: [ defaults, lazytime, noatime, inode64, logbsize=256k, noquota ]
     - filesystem: f2fs

--- a/src/modules/mount/mount.schema.yaml
+++ b/src/modules/mount/mount.schema.yaml
@@ -36,6 +36,7 @@ properties:
             properties:
                 filesystem: { type: string }
                 options: { type: array }
+                nvmeOptions: { type: array }
                 ssdOptions: { type: array }
                 hddOptions: { type: array }
             required: [ filesystem ]


### PR DESCRIPTION
Rebased version of https://github.com/CachyOS/cachyos-calamares/pull/64

This will reduce ratio (though not by much), but it will speed up
writes and reads in some cases, since NVMe devices are fast enough
anyway and the average CPU becomes a bottleneck.

See: https://gist.github.com/braindevices/fde49c6a8f6b9aaf563fb977562aafec

Closes: https://github.com/CachyOS/cachyos-calamares/issues/59