### PR TITLE
netinstall: Remove ffmpegthumbnailer

### DIFF
--- a/src/modules/netinstall/netinstall.yaml
+++ b/src/modules/netinstall/netinstall.yaml
@@ -86,7 +86,6 @@
         packages:
           - accountsservice
           - bash-completion
-          - ffmpegthumbnailer
           - gst-libav
           - gst-plugin-pipewire
           - gst-plugins-bad

--- a/src/modules/netinstall/netinstall.yaml
+++ b/src/modules/netinstall/netinstall.yaml
@@ -289,6 +289,7 @@
     - ristretto
     - thunar-archive-plugin
     - thunar-media-tags-plugin
+    - ffmpegthumbnailer
     - xdg-user-dirs-gtk
     - xed
     - xfce4
@@ -350,6 +351,7 @@
     - nemo
     - nemo-fileroller
     - nemo-preview
+    - ffmpegthumbnailer
     - network-manager-applet
     - sushi
     - totem
@@ -367,6 +369,7 @@
     - gnome-terminal
     - blueberry
     - metacity
+    - ffmpegthumbnailer
     - lightdm
     - lightdm-gtk-greeter
 - name: "Cosmic"
@@ -568,6 +571,7 @@
     - tint2
     - ttf-nerd-fonts-symbols
     - tumbler
+    - ffmpegthumbnailer
     - xbindkeys
     - xcursor-neutral
     - xdg-user-dirs-gtk


### PR DESCRIPTION
Removes ffmpegthumbnailer from the default package list.

- Reduces unnecessary background I/O and resource usage by default.
- DEs (like KDE) use better-integrated alternatives like ffmpegthumbs.
- Keeps the base system clean and follows the "opt-in" principle for specific multimedia tools.