### PR TITLE
netinstall: Remove vi

### DIFF
--- a/src/modules/netinstall/netinstall.yaml
+++ b/src/modules/netinstall/netinstall.yaml
@@ -173,7 +173,6 @@
           - python-defusedxml
           - python-packaging
           - rsync
-          - vi
           - wget
           - ripgrep
           - micro


### PR DESCRIPTION
Removed the vi package as it has been officially dropped from the Arch Linux repositories.