### PR TITLE
[mount] manual partitioning & btrfs setup

### DIFF
--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -323,7 +323,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
                     err(f"Btrfs subvolume not defined {device}",am) # instead of continue
                 sub_path = setup_dir + s["subvolume"]
                 if os.path.exists(sub_path): # if this exists user is at fault
-                    err(f"Subvolume {s['subvolume']} already exists. Please format the partition to avoid a messy installation.", am)
+                    err(f"Subvolume {s['subvolume']} already exists on {device}. Please format the partition to avoid a messy installation.", am)
             for s in btrfs_subvolumes: # 2. Execution: All checks passed ("Luft ist rein")
                 sub_path = setup_dir + s["subvolume"]
                 os.makedirs(os.path.dirname(sub_path), exist_ok=True)

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -283,10 +283,10 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     device = partition["device"]
 
     if fstype in ["fat16", "fat32", "ntfs", "ext2", "exfat"]:
-        is_boot = raw_mount_point in ["/boot", "/boot/efi"]
         # Block if: not a boot path, OR fat16/ntfs/ext2/exfat
-        if not is_boot or fstype in ["fat16", "ntfs", "ext2", "exfat"]:
-            err(f"Unsupported partition with {fstype} on {raw_mount_point}",am)
+        is_boot = raw_mount_point in ["/boot", "/boot/efi"]
+        if not (is_boot and fstype == "fat32"):
+            err(f"Unsupported {fstype} on {raw_mount_point}", am)
         fstype = "vfat"
 
     if "luksMapperName" in partition:

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -357,7 +357,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
             # This tells Linux: "Put this specific subvolume here"
             sub_opts = f"subvol={s['subvolume']},{mount_options_string}"
         else:
-            err("subvolume not defined",am) # not allowing this here
+            err("subvolume not defined",am) # instead of mounting entire filesystem
 
         # This builds the path INSIDE your new root
         sub_path = root_mount_point + s["mountPoint"]

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -361,7 +361,7 @@ def run():
 
     # Get the mountOptions, if this is None, that is OK and will be handled later
     mount_options = libcalamares.job.configuration.get("mountOptions")
-    
+
     # Guard against missing keys (generally a sign that the config file is bad)
     extra_mounts = libcalamares.job.configuration.get("extraMounts") or []
     if not extra_mounts:

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -270,11 +270,14 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     # Step 1: Private side-mount to create subvolumes
     with tempfile.TemporaryDirectory(prefix="calam-btrfs-") as setup_dir:
         libcalamares.utils.mount(device, setup_dir, fstype, "defaults")
-        for s in btrfs_subvolumes:
-            if s["subvolume"]:
-                os.makedirs(setup_dir + os.path.dirname(s["subvolume"]), exist_ok=True)
-                subprocess.check_call(["btrfs", "subvolume", "create", setup_dir + s["subvolume"]])
-
+        try:  # <--- You need this line!
+            for s in btrfs_subvolumes:
+                if s["subvolume"]:
+                    os.makedirs(setup_dir + os.path.dirname(s["subvolume"]), exist_ok=True)
+                    subprocess.check_call(["btrfs", "subvolume", "create", setup_dir + s["subvolume"]])
+        finally: # <--- This matches the 'try'
+            # Manually release the SSD so Python can delete setup_dir
+            subprocess.check_call(["umount", "-v", setup_dir])
     # Step 2: Swap raw mount for @ subvolume mount
     subprocess.check_call(["umount", "-v", root_mount_point])
     

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -314,7 +314,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
                 ]
             contents = [f for f in os.listdir(mount_point) if f not in ignored_metadata]
             if contents:
-                err(f"Partition {device} has data. Please format.", am)
+                err(f"Partition {device} has data. Please format or use /home or /srv.", am)
 
         return
 

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -310,7 +310,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         if raw_mount_point not in ["/home", "/srv", "/boot", "/boot/efi"]:
             contents = [f for f in os.listdir(mount_point) if f != "lost+found"]
             if contents:
-                err(f"Partition {device} has data. Please format!", am)
+                err(f"Partition {device} has data. Please format.", am)
 
         return
 
@@ -329,7 +329,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
                     err(f"Btrfs subvolume not defined {device}", am) # instead of continue
                 sub_path = setup_dir + s["subvolume"]
                 if os.path.exists(sub_path): # if this exists user is at fault
-                    err(f"Subvolume {s['subvolume']} already exists on {device}. Please format the partition to avoid a messy installation.", am)
+                    err(f"Subvolume {s['subvolume']} already exists on {device}. Please format.", am)
             for s in btrfs_subvolumes: # 2. Execution: All checks passed ("Luft ist rein")
                 sub_path = setup_dir + s["subvolume"]
                 os.makedirs(os.path.dirname(sub_path), exist_ok=True)

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -299,6 +299,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         mount_zfs(root_mount_point, partition)
         return
 
+
     mount_options_string = get_mount_options(fstype, mount_options, partition, efi_location)
     mount_options_list.append({"mountpoint": raw_mount_point, "option_string": mount_options_string})
     is_virtual = any(raw_mount_point.startswith(v) for v in ["/sys", "/proc", "/dev", "/run"])

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -338,6 +338,8 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     # Store created list in global storage so it can be used in the fstab module
     libcalamares.globalstorage.insert("btrfsSubvolumes", btrfs_subvolumes)
     # Insert the root subvolume into global storage
+    # The fstab module uses this key to inject 'subvol=/@'
+    # into the generic '/' entry created earlier.
     libcalamares.globalstorage.insert("btrfsRootSubvolume", root_sub['subvolume'])
 
     # Mount raw partition to create subvolumes

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -354,7 +354,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     # Find the root subvolume (usually /@)
     root_sub = next((s for s in btrfs_subvolumes if s["mountPoint"] == "/"), None)
     if not root_sub:
-        err(f"Btrfs root subvolume (/) not found!", am)
+        err(f"Btrfs root subvolume not found!", am)
 
     # Mount the specific @ subvolume to the root mount point
     if root_sub['subvolume']:

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -409,9 +409,7 @@ def run():
     if libcalamares.globalstorage.value("firmwareType") == "efi":
         efi_location = libcalamares.globalstorage.value("efiSystemPartition")
     else:
-        for mount in extra_mounts:
-            if mount.get("efi", None) is True:
-                extra_mounts.remove(mount)
+        extra_mounts = [m for m in extra_mounts if not m.get("efi")]
 
     # Add extra mounts to the partitions list and sort by mount points.
     # This way, we ensure / is mounted before the rest, and every mount point

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -269,32 +269,27 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     btrfs_subvolumes = get_btrfs_subvolumes(partitions)
     libcalamares.globalstorage.insert("btrfsSubvolumes", btrfs_subvolumes)
 
-    # Step 1: Create subvolumes via a private "backdoor" mount
     with tempfile.TemporaryDirectory(prefix="calam-btrfs-") as setup_dir:
+        # Mount raw partition to create subvolumes
         libcalamares.utils.mount(device, setup_dir, fstype, "defaults")
-        try:  # <--- You need this line!
+        try:
             for s in btrfs_subvolumes:
-                if s["subvolume"]:
-                    os.makedirs(setup_dir + os.path.dirname(s["subvolume"]), exist_ok=True)
-                    subprocess.check_call(["btrfs", "subvolume", "create", setup_dir + s["subvolume"]])
-                    # Secure /root subvolume permissions
+                sub_path = setup_dir + s["subvolume"]
+                if not os.path.exists(sub_path):
+                    os.makedirs(os.path.dirname(sub_path), exist_ok=True)
+                    subprocess.check_call(["btrfs", "subvolume", "create", sub_path])
                     if s["mountPoint"] == "/root":
-                        os.chmod(setup_dir + s["subvolume"], 0o750)
+                        os.chmod(sub_path, 0o750)
         finally:
-            # UNMOUNT 1: Close the "backdoor" so the temp directory can be cleaned up
-            # We must clear this so we can remount using the '@' subvolume specifically.
             subprocess.check_call(["umount", "-v", setup_dir])
-    
-    # Step 2: Prepare for the real mount
-    try:
-        # UNMOUNT 2: Remove the "flat" partition mount Calamares created earlier.
-        subprocess.call(["umount", "-l", root_mount_point])
-    except Exception:
-        pass
-        
+
+    # Find the root subvolume (usually /@)
     root_sub = next((s for s in btrfs_subvolumes if s["mountPoint"] == "/"), None)
-    if not root_sub:
-        raise Exception("No root (/) subvolume defined!")
+    
+    # Mount the specific @ subvolume to the root mount point
+    root_opts = f"subvol={root_sub['subvolume']},{mount_options_string}"
+    if libcalamares.utils.mount(device, root_mount_point, fstype, root_opts) != 0:
+        raise Exception(f"Failed to mount root subvolume")
 
     root_opts = f"subvol={root_sub['subvolume']},{mount_options_string}"
     if libcalamares.utils.mount(device, root_mount_point, fstype, root_opts) != 0:

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -252,8 +252,6 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         return
 
     mount_point = root_mount_point + raw_mount_point
-
-    device = partition["device"]
     
     # Ensure that the created directory has the correct SELinux context on
     # SELinux-enabled systems.
@@ -272,6 +270,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     if fstype == "unformatted":
         return
 
+    device = partition["device"]
     if fstype in ["fat16", "fat32", "exfat", "ntfs", "ext2"]:
         is_boot = raw_mount_point in ["/boot", "/boot/efi"]
         # Block if: not a boot path, OR ntfs/ext2, OR exfat on UEFI

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -418,6 +418,7 @@ def run():
     # This way, we ensure / is mounted before the rest, and every mount point
     # is created on the right partition (e.g. if a partition is to be mounted
     # under /tmp, we make sure /tmp is mounted before the partition)
+
     # mount_options_list will be inserted into global storage for use in fstab later
     mount_options_list = []
     active_mounts = []

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -283,8 +283,8 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
 
     if fstype in ["fat16", "fat32", "ntfs", "ext2", "exfat"]:
         is_boot = raw_mount_point in ["/boot", "/boot/efi"]
-        # Block if: not a boot path, OR ntfs/ext2/exfat
-        if not is_boot or fstype in ["ntfs", "ext2", "exfat"]:
+        # Block if: not a boot path, OR fat16/ntfs/ext2/exfat
+        if not is_boot or fstype in ["fat16", "ntfs", "ext2", "exfat"]:
             err(f"Unsupported partition with {fstype} on {raw_mount_point}",am)
         fstype = "vfat"
 

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -312,7 +312,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         try: # <--- You need this line!
             for s in btrfs_subvolumes:
                 if not s["subvolume"]:
-                    continue
+                    continue # better not crash here
                 sub_path = setup_dir + s["subvolume"]
                 if not os.path.exists(sub_path):
                     os.makedirs(os.path.dirname(sub_path), exist_ok=True)

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -279,8 +279,12 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
             # Manually release the SSD so Python can delete setup_dir
             subprocess.check_call(["umount", "-v", setup_dir])
     # Step 2: Swap raw mount for @ subvolume mount
-    subprocess.check_call(["umount", "-l", "-v", root_mount_point])
-    
+    try:
+        #if os.path.ismount(root_mount_point):
+        subprocess.call(["umount", "-l", root_mount_point])
+    except Exception:
+        pass
+        
     root_sub = next((s for s in btrfs_subvolumes if s["mountPoint"] == "/"), None)
     if not root_sub:
         raise Exception("No root (/) subvolume defined!")
@@ -302,7 +306,8 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         
         if libcalamares.utils.mount(device, sub_path, fstype, sub_opts) != 0:
             libcalamares.utils.warning(f"Failed to mount subvolume {s['subvolume']}")
-            
+    # Add this after the root subvolume mount succeeds:
+    mount_options_list.append({"mountpoint": "/", "option_string": root_opts})    
 def enable_swap_partition(devices):
     try:
         for d in devices:

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -351,7 +351,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
                 sub_path = setup_dir + s["subvolume"]
                 if os.path.exists(sub_path):
                     err((
-                        f"Subvolume {s['subvolume']} exists on {device}. "
+                        f"Subvolume {s['subvolume']} already exists on {device}. "
                         "Only /home or /srv allowed."), am)
             for s in btrfs_subvolumes:
                 sub_path = setup_dir + s["subvolume"]

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -285,7 +285,6 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         is_boot = raw_mount_point in ["/boot", "/boot/efi"]
         # Block if: not a boot path, OR ntfs/ext2/exfat
         if not is_boot or fstype in ["ntfs", "ext2", "exfat"]:
-            # instead of returning we avoid the fstab problem
             err(f"Unsupported partition with {fstype} on {raw_mount_point}",am)
         fstype = "vfat"
 
@@ -328,13 +327,13 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         if libcalamares.utils.mount(device, setup_dir, fstype, "defaults") != 0:
             err(f"Cannot mount btrfs for subvolume creation {device}", am)
         try: # <--- You need this line!
-            for s in btrfs_subvolumes: # 1. Pre-validation: Is the coast clear?
+            for s in btrfs_subvolumes: # 1. Pre-validation
                 if not s["subvolume"]:
                     err(f"Btrfs subvolume not defined {device}", am) # instead of continue
                 sub_path = setup_dir + s["subvolume"]
-                if os.path.exists(sub_path): # if this exists user is at fault
+                if os.path.exists(sub_path):
                     err(f"Subvolume {s['subvolume']} already exists on {device}. Please format.", am)
-            for s in btrfs_subvolumes: # 2. Execution: All checks passed ("Luft ist rein")
+            for s in btrfs_subvolumes: # 2. Execution
                 sub_path = setup_dir + s["subvolume"]
                 os.makedirs(os.path.dirname(sub_path), exist_ok=True)
                 subprocess.check_call(["btrfs", "subvolume", "create", sub_path])
@@ -370,7 +369,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
             # This tells Linux: "Put this specific subvolume here"
             sub_opts = f"subvol={s['subvolume']},{mount_options_string}"
         else:
-            err("subvolume not defined", am) # instead of mounting entire filesystem
+            err("subvolume not defined", am) # not mounting entire filesystem
 
         # This builds the path INSIDE your new root
         sub_path = root_mount_point + s["mountPoint"]

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -138,6 +138,8 @@ def get_btrfs_subvolumes(partitions):
         because they get a dedicated partition instead.
     """
     btrfs_subvolumes = libcalamares.job.configuration.get("btrfsSubvolumes", None)
+    # Warn if there's no configuration at all, and empty configurations are
+    # replaced by a simple root-only layout.
     if btrfs_subvolumes is None:
         libcalamares.utils.warning("No configuration for btrfsSubvolumes")
     if not btrfs_subvolumes:

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -381,6 +381,9 @@ def run():
     except ZfsException as ze:
         return _("zfs mounting error"), ze.message
 
+    if not mount_options_list:
+        libcalamares.utils.warning("No mount options defined, {!s} partitions, {!s} mountable".format(len(partitions), len(mountable_partitions)))
+
     # 6. Global Storage Persistence
     libcalamares.globalstorage.insert("rootMountPoint", root_mount_point)
     libcalamares.globalstorage.insert("mountOptionsList", mount_options_list)

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -394,7 +394,8 @@ def run():
     if not mount_options_list:
         libcalamares.utils.warning("No mount options defined, {!s} partitions, {!s} mountable".format(len(partitions), len(mountable_partitions)))
 
-    # 6. Global Storage Persistence
     libcalamares.globalstorage.insert("rootMountPoint", root_mount_point)
     libcalamares.globalstorage.insert("mountOptionsList", mount_options_list)
+
+    # Remember the extra mounts for the unpackfs module
     libcalamares.globalstorage.insert("extraMounts", extra_mounts)

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -337,9 +337,9 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
 
     # Store created list in global storage so it can be used in the fstab module
     libcalamares.globalstorage.insert("btrfsSubvolumes", btrfs_subvolumes)
-    # Insert the root subvolume into global storage
-    # The fstab module uses this key to inject 'subvol=/@'
-    # into the generic '/' entry created earlier.
+    # TECHNICAL DEBT ALERT: Calamares' fstab module expects a generic '/' entry
+    # in mount_options_list first. It then uses this 'btrfsRootSubvolume' key
+    # to find that generic entry and inject the 'subvol=@' string later.
     libcalamares.globalstorage.insert("btrfsRootSubvolume", root_sub['subvolume'])
 
     # Mount raw partition to create subvolumes

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -277,6 +277,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     if fstype == "unformatted":
         return
 
+
     am = active_mounts
     am.append(mount_point)
     device = partition["device"]

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -260,8 +260,11 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
 
     try:
         subprocess.call(['chcon', '--reference=' + raw_mount_point, mount_point])
-    except:
-        pass
+    except FileNotFoundError as e:
+        libcalamares.utils.warning(str(e))
+    except OSError:
+        libcalamares.utils.error("Cannot run 'chcon' normally.")
+        raise
 
     fstype = partition.get("fs", "").lower()
     if fstype == "unformatted":

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -169,12 +169,11 @@ def get_btrfs_subvolumes(partitions):
     return btrfs_subvolumes
 
 
-def mount_zfs(root_mount_point, partition, am):
+def mount_zfs(root_mount_point, partition):
     """ Mounts a zfs partition at @p root_mount_point
 
     :param root_mount_point: The absolute path to the root of the install
     :param partition: The partition map from global storage for this partition
-    :param am: crash helper
     :return:
     """
     # Get the list of zpools from global storage
@@ -228,7 +227,6 @@ def mount_zfs(root_mount_point, partition, am):
             except subprocess.CalledProcessError:
                 raise ZfsException(_("Failed to set zfs mountpoint"))
     else:
-        err("Manual ZFS unsupported. Use 'Erase Disk'.", am) # this doesnt install correctly
         try:
             libcalamares.utils.host_env_process_output(["zfs", "mount", pool_name + '/' + ds_name])
         except subprocess.CalledProcessError:
@@ -294,7 +292,9 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         device = os.path.join("/dev/mapper", partition["luksMapperName"])
 
     if fstype == "zfs":
-        mount_zfs(root_mount_point, partition, am)
+        if raw_mount_point != '/':
+            err("Manual ZFS unsupported. Use 'Erase Disk'.", am) # this doesnt install correctly
+        mount_zfs(root_mount_point, partition)
         return
 
     mount_options_string = get_mount_options(fstype, mount_options, partition, efi_location)

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -281,7 +281,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     am.append(mount_point)
     device = partition["device"]
 
-    if fstype in ["fat16", "fat32", "exfat", "ntfs", "ext2"]:
+    if fstype in ["fat16", "fat32", "ntfs", "ext2", "exfat"]:
         is_boot = raw_mount_point in ["/boot", "/boot/efi"]
         # Block if: not a boot path, OR ntfs/ext2/exfat
         if not is_boot or fstype in ["ntfs", "ext2", "exfat"]:

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -313,7 +313,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
             for s in btrfs_subvolumes:
                 if not s["subvolume"]:
                     err(f"Btrfs subvolume not defined {device}",am) # hard relying on the config 
-                    # continue # not throwing exception, ignoring invalid config
+                    ### continue ### not throwing exception, ignoring invalid config
                 sub_path = setup_dir + s["subvolume"]
                 if not os.path.exists(sub_path):
                     os.makedirs(os.path.dirname(sub_path), exist_ok=True)

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -264,7 +264,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         fstype = "vfat"
 
     device = partition["device"]
-    
+
     if "luksMapperName" in partition:
         device = os.path.join("/dev/mapper", partition["luksMapperName"])
 

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -292,7 +292,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     if "luksMapperName" in partition:
         device = os.path.join("/dev/mapper", partition["luksMapperName"])
 
-    if fstype == "zfs": 
+    if fstype == "zfs":
         mount_zfs(root_mount_point, partition)
         return
 

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -348,13 +348,16 @@ def run():
     partitions = libcalamares.globalstorage.value("partitions")
 
     if not partitions:
-        libcalamares.utils.warning("partitions is empty")
-        return (_("Configuration Error"), _("No partitions defined."))
+        libcalamares.utils.warning("partitions is empty, {!s}".format(partitions))
+        return (_("Configuration Error"),
+                _("No partitions are defined for <pre>{!s}</pre> to use.").format("mount"))
 
-    # 1. Restore Swap Activation (Physical swap first)
-    claimed_swap = [p for p in partitions if p["fs"] == "linuxswap" and p.get("claimed", False)]
-    swap_devices = [p["device"] if p["fsName"] == "linuxswap" else 
-                    "/dev/mapper/" + p["luksMapperName"] for p in claimed_swap]
+    # Find existing swap partitions that are part of the installation and enable them now
+    claimed_swap_partitions = [p for p in partitions if p["fs"] == "linuxswap" and p.get("claimed", False)]
+    plain_swap = [p for p in claimed_swap_partitions if p["fsName"] == "linuxswap"]
+    luks_swap = [p for p in claimed_swap_partitions if p["fsName"] == "luks" or p["fsName"] == "luks2"]
+    swap_devices = [p["device"] for p in plain_swap] + ["/dev/mapper/" + p["luksMapperName"] for p in luks_swap]
+
     enable_swap_partition(swap_devices)
 
     root_mount_point = tempfile.mkdtemp(prefix="calamares-root-")

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -345,7 +345,6 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
             libcalamares.globalstorage.insert("btrfsRootSubvolume", s["subvolume"])
             continue
 
-        # Handle "breadcrumb" logic for empty subvolume names
         if s['subvolume']:
             # This tells Linux: "Put this specific subvolume here"
             sub_opts = f"subvol={s['subvolume']},{mount_options_string}"

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -310,7 +310,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         sub_opts = f"subvol={s['subvolume']},{mount_options_string}"
         
         if libcalamares.utils.mount(device, sub_path, fstype, sub_opts) == 0:
-            mount_options_list.append({"mountpoint": raw_mount_point, "option_string": mount_options_string})
+            mount_options_list.append({"mountpoint": s["mountPoint"], "option_string": mount_options_string})
         else:
             libcalamares.utils.warning(f"Failed to mount subvolume {s['subvolume']}")
             

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -336,11 +336,6 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     if not root_sub:
         err("Btrfs config error: root subvolume not found", am)
 
-    # Store created list in global storage so it can be used in the fstab module
-    libcalamares.globalstorage.insert("btrfsSubvolumes", btrfs_subvolumes)
-    # Fstab uses btrfsRootSubvolume to inject subvol=/@ into generic / entry
-    libcalamares.globalstorage.insert("btrfsRootSubvolume", root_sub['subvolume'])
-
     # Mount raw partition to create subvolumes
     with tempfile.TemporaryDirectory(prefix="calam-btrfs-") as setup_dir:
         am.append(setup_dir)
@@ -386,6 +381,11 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
             mount_options_list.append({"mountpoint": s["mountPoint"], "option_string": mount_options_string})
         else:
             err(f"Failed to mount subvolume {s['subvolume']}", am)
+
+    # Store created list in global storage so it can be used in the fstab module
+    libcalamares.globalstorage.insert("btrfsSubvolumes", btrfs_subvolumes)
+    # Fstab uses btrfsRootSubvolume to inject subvol=/@ into generic / entry
+    libcalamares.globalstorage.insert("btrfsRootSubvolume", root_sub['subvolume'])
 
 
 def enable_swap_partition(devices):

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -368,7 +368,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     # insert the root subvolume into global storage
     libcalamares.globalstorage.insert("btrfsRootSubvolume", root_sub['subvolume'])
 
-    # Mount subvolumes
+    # Mount remaining subvolumes
     for s in btrfs_subvolumes:
         if s["mountPoint"] == "/":
             continue

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -326,7 +326,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     root_sub = next((s for s in btrfs_subvolumes if s["mountPoint"] == "/"), None)
     if not root_sub:
         libcalamares.utils.warning(f"Btrfs root subvolume (/) not found")
-        raise Exception("Btrfs root subvolume (/) not found!")
+        raise Exception(f"Btrfs root subvolume (/) not found!")
 
     # Mount the specific @ subvolume to the root mount point
     if root_sub['subvolume']:

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -300,17 +300,16 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
 
     mount_options_string = get_mount_options(fstype, mount_options, partition, efi_location)
     mount_options_list.append({"mountpoint": raw_mount_point, "option_string": mount_options_string})
-    
+    is_virtual = any(raw_mount_point.startswith(v) for v in ["/sys", "/proc", "/dev", "/run"])
     # Standard mount for everything EXCEPT Btrfs root (this catches other btrfs partitions)
     if not (fstype == "btrfs" and raw_mount_point == '/'):
-        # 1. Perform the mount
         if libcalamares.utils.mount(device, mount_point, fstype, mount_options_string) != 0:
             err(f"Cannot mount {device}", am)
-        # 2. Check for "ghost" data immediately after
-        #if raw_mount_point not in ["/home", "/srv", "/boot", "/boot/efi"]:
-            #contents = [f for f in os.listdir(mount_point) if f != "lost+found"]
-            #if contents:
-                #err(f"Partition {device} has data. Please format.", am)
+        # check only relevant partitions for ghost data
+        if not is_virtual and raw_mount_point not in ["/home", "/srv", "/boot", "/boot/efi"]:
+            contents = [f for f in os.listdir(mount_point) if f != "lost+found"]
+            if contents:
+                err(f"Partition {device} has data. Please format.", am)
 
         return
 

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -361,7 +361,6 @@ def run():
 
     # Get the mountOptions, if this is None, that is OK and will be handled later
     mount_options = libcalamares.job.configuration.get("mountOptions")
-    mount_options_list = []
     
     # Guard against missing keys (generally a sign that the config file is bad)
     extra_mounts = libcalamares.job.configuration.get("extraMounts") or []
@@ -373,6 +372,8 @@ def run():
         efi_location = libcalamares.globalstorage.value("efiSystemPartition")
     else:
         extra_mounts = [m for m in extra_mounts if not m.get("efi")]
+
+    mount_options_list = []
 
     # 4. Phase One: Physical (Depth Sort: / before /var)  
     physical = [p for p in partitions if "mountPoint" in p and p["mountPoint"]]

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -346,6 +346,7 @@ def run():
     """
 
     partitions = libcalamares.globalstorage.value("partitions")
+
     if not partitions:
         libcalamares.utils.warning("partitions is empty")
         return (_("Configuration Error"), _("No partitions defined."))

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -271,12 +271,13 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     if fstype == "unformatted":
         return
 
-    if fstype in ["fat16", "fat32", "exfat", "ntfs"]:
-        # Block non-FAT or any non-boot path
-        if fstype in ["exfat", "ntfs"] or raw_mount_point not in ["/boot", "/boot/efi"]:
+    if fstype in ["fat16", "fat32", "exfat", "ntfs", "ext2"]:
+        is_boot = raw_mount_point in ["/boot", "/boot/efi"]
+        # Block if: not a boot path, OR ntfs/ext2, OR exfat on UEFI
+        if not is_boot or fstype in ["ntfs", "ext2"] or (fstype == "exfat" and efi_location):
             libcalamares.utils.warning(f"Skipping {fstype} on {raw_mount_point}")
             return
-        fstype = "vfat"
+        fstype = "vfat" if fstype != "exfat" else "exfat"
 
     if "luksMapperName" in partition:
         device = os.path.join("/dev/mapper", partition["luksMapperName"])
@@ -315,24 +316,24 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
 
     # Find the root subvolume (usually /@)
     root_sub = next((s for s in btrfs_subvolumes if s["mountPoint"] == "/"), None)
-    
+
     # Mount the specific @ subvolume to the root mount point
     root_opts = f"subvol={root_sub['subvolume']},{mount_options_string}"
     if libcalamares.utils.mount(device, root_mount_point, fstype, root_opts) != 0:
         libcalamares.utils.warning(f"Cannot mount root subvolume {device}")
-        
+
     # Step 3: Mount remaining subvolumes (like /home)
     for s in btrfs_subvolumes:
         if s["mountPoint"] == "/":
             libcalamares.globalstorage.insert("btrfsRootSubvolume", s["subvolume"])
             continue
-            
+
         # This builds the path INSIDE your new root
         sub_path = root_mount_point + s["mountPoint"]
         os.makedirs(sub_path, exist_ok=True)
         # This tells Linux: "Put this specific subvolume here"
         sub_opts = f"subvol={s['subvolume']},{mount_options_string}"
-        
+
         if libcalamares.utils.mount(device, sub_path, fstype, sub_opts) == 0:
             mount_options_list.append({"mountpoint": s["mountPoint"], "option_string": mount_options_string})
         else:

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -286,7 +286,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     if fstype in ["fat16", "fat32", "ntfs", "ext2", "exfat"]:
         is_boot = raw_mount_point in ["/boot", "/boot/efi"]
         if not (is_boot and fstype == "fat32"):
-            err(f"Unsupported {fstype} on {raw_mount_point}", am)
+            err(f"Unsupported {fstype} partition on {raw_mount_point}", am)
         fstype = "vfat"
 
     if "luksMapperName" in partition:

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -268,8 +268,11 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
 
     try:
         subprocess.call(['chcon', '--reference=' + raw_mount_point, mount_point])
-    except:
-        pass
+    except FileNotFoundError as e:
+        libcalamares.utils.warning(str(e))
+    except OSError:
+        libcalamares.utils.error("Cannot run 'chcon' normally.")
+        raise
 
     fstype = partition.get("fs", "").lower()
     if fstype == "unformatted":

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -261,6 +261,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         return
 
     mount_point = root_mount_point + raw_mount_point
+
     am = active_mounts
     am.append(mount_point)
     # Ensure that the created directory has the correct SELinux context on

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -272,7 +272,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         pass
 
     fstype = partition.get("fs", "").lower()
-    if fstype == "unformatted":
+    if fstype == "unformatted": # why is this here
         return
 
     device = partition["device"]

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -282,7 +282,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     am.append(mount_point)
     device = partition["device"]
 
-    # Only allow fat32 on boot path
+    # Only allow fat32 on boot path, block incompatible
     if fstype in ["fat16", "fat32", "ntfs", "ext2", "exfat"]:
         is_boot = raw_mount_point in ["/boot", "/boot/efi"]
         if not (is_boot and fstype == "fat32"):

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -293,9 +293,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
 
     if fstype == "zfs":
         if raw_mount_point != '/':
-            # Manual sub-partitions fail because mkinitcpio hooks aren't
-            # properly configured outside of the 'Erase Disk' workflow,
-            # leading to pacstrap failures (missing zfs-utils/hooks).
+            # pacstrap failure mkinitcpio hook missing
             err("Manual ZFS unsupported. Use 'Erase Disk'.", am)
         mount_zfs(root_mount_point, partition)
         return

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -277,7 +277,6 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     if fstype == "unformatted":
         return
 
-
     am = active_mounts
     am.append(mount_point)
     device = partition["device"]

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -293,7 +293,10 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
 
     if fstype == "zfs":
         if raw_mount_point != '/':
-            err("Manual ZFS unsupported. Use 'Erase Disk'.", am) # this doesnt install correctly
+            # Manual sub-partitions fail because mkinitcpio hooks aren't
+            # properly configured outside of the 'Erase Disk' workflow,
+            # leading to pactsrap failures (missing zfs-utils/hooks).
+            err("Manual ZFS unsupported. Use 'Erase Disk'.", am)
         mount_zfs(root_mount_point, partition)
         return
 

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -231,12 +231,12 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     os.makedirs(mount_point, exist_ok=True)
     fstype = partition.get("fs", "").lower()
 
-    is_virtual = any(raw_mount_point.startswith(v) for v in ["/sys", "/proc", "/dev", "/run"])
-    if not is_virtual and fstype != "unformatted":
-        try:
-            os.chmod(mount_point, 0o755)
-        except OSError as e:
-            libcalamares.utils.warning(f"Could not chmod {mount_point}: {e}")
+    #is_virtual = any(raw_mount_point.startswith(v) for v in ["/sys", "/proc", "/dev", "/run"])
+    #if not is_virtual and fstype != "unformatted":
+        #try:
+            #os.chmod(mount_point, 0o755)
+        #except OSError as e:
+            #libcalamares.utils.warning(f"Could not chmod {mount_point}: {e}")
 
     try:
         subprocess.call(['chcon', '--reference=' + raw_mount_point, mount_point])

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -299,7 +299,6 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
 
     mount_options_string = get_mount_options(fstype, mount_options, partition, efi_location)
     mount_options_list.append({"mountpoint": raw_mount_point, "option_string": mount_options_string})
-    is_virtual = any(raw_mount_point.startswith(v) for v in ["/sys", "/proc", "/dev", "/run"])
 
     # Standard mount for everything EXCEPT Btrfs root (this catches other btrfs partitions)
     if not (fstype == "btrfs" and raw_mount_point == '/'):
@@ -307,6 +306,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
             err(f"Cannot mount {device}", am)
 
         # Verify that the install target is empty
+        is_virtual = any(raw_mount_point.startswith(v) for v in ["/sys", "/proc", "/dev", "/run"])
         if not is_virtual and raw_mount_point not in ["/home", "/srv", "/boot", "/boot/efi"]:
             ignored_metadata = [
                 "lost+found", ".Trash-1000", "$RECYCLE.BIN", 

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -312,8 +312,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         try: # <--- You need this line!
             for s in btrfs_subvolumes:
                 if not s["subvolume"]:
-                    err(f"Btrfs subvolume not defined {device}",am) # relying on mount.conf 
-                    ### continue ### ignoring invalid config
+                    err(f"Btrfs subvolume not defined {device}",am) # instead of continue
                 sub_path = setup_dir + s["subvolume"]
                 if not os.path.exists(sub_path):
                     os.makedirs(os.path.dirname(sub_path), exist_ok=True)

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -309,9 +309,12 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         # This tells Linux: "Put this specific subvolume here"
         sub_opts = f"subvol={s['subvolume']},{mount_options_string}"
         
-        if libcalamares.utils.mount(device, sub_path, fstype, sub_opts) != 0:
+        if libcalamares.utils.mount(device, sub_path, fstype, sub_opts) == 0:
+            mount_options_list.append({"mountpoint": raw_mount_point, "option_string": mount_options_string})
             libcalamares.utils.warning(f"Failed to mount subvolume {s['subvolume']}")
-  
+        else:
+            libcalamares.utils.warning(f"Failed to mount subvolume {s['subvolume']}")
+            
 def enable_swap_partition(devices):
     try:
         for d in devices:

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -295,7 +295,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         if raw_mount_point != '/':
             # Manual sub-partitions fail because mkinitcpio hooks aren't
             # properly configured outside of the 'Erase Disk' workflow,
-            # leading to pactsrap failures (missing zfs-utils/hooks).
+            # leading to pacstrap failures (missing zfs-utils/hooks).
             err("Manual ZFS unsupported. Use 'Erase Disk'.", am)
         mount_zfs(root_mount_point, partition)
         return

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -433,9 +433,6 @@ def run():
     except ZfsException as ze:
         return _("zfs mounting error"), ze.message
 
-    if not mount_options_list:
-        libcalamares.utils.warning("No mount options defined, {!s} partitions, {!s} mountable, {!s} extraMounts".format(len(partitions), len(physical), len(extra)))
-
     libcalamares.globalstorage.insert("rootMountPoint", root_mount_point)
     libcalamares.globalstorage.insert("mountOptionsList", mount_options_list)
 

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -365,7 +365,7 @@ def run():
 
     # 4. Phase One: Physical (Depth Sort: / before /var)  
     physical = [p for p in partitions if "mountPoint" in p and p["mountPoint"]]
-    physical.sort(key=lambda x: x["mountPoint"].count('/'))
+    physical.sort(key=lambda x: x["mountPoint"])
 
     try:
         for p in physical:
@@ -373,7 +373,7 @@ def run():
          
         # 5. Phase Two: Bind/Virtual (After Btrfs subvolumes exist)
         extra = [p for p in extra_mounts if "mountPoint" in p and p["mountPoint"]]
-        extra.sort(key=lambda x: x["mountPoint"].count('/'))
+        extra.sort(key=lambda x: x["mountPoint"])
 
         for p in extra:
             mount_partition(root_mount_point, p, partitions, mount_options, mount_options_list, efi_location)

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -275,7 +275,8 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         is_boot = raw_mount_point in ["/boot", "/boot/efi"]
         # Block if: not a boot path, OR ntfs/ext2, OR exfat on UEFI
         if not is_boot or fstype in ["ntfs", "ext2"] or (fstype == "exfat" and efi_location):
-            libcalamares.utils.warning(f"Skipping {fstype} on {raw_mount_point}")
+            libcalamares.utils.warning(f"Unsupported partition with {fstype} on {raw_mount_point}")
+            raise Exception(f"Unsupported partition with {fstype} on {raw_mount_point}")
             return
         fstype = "vfat" if fstype != "exfat" else "exfat"
 

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -369,7 +369,6 @@ def run():
 
     mount_options_list = []
 
-    # 3. EFI Logic (Filtered properly)
     efi_location = None
     if libcalamares.globalstorage.value("firmwareType") == "efi":
         efi_location = libcalamares.globalstorage.value("efiSystemPartition")

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -252,7 +252,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         return
 
     mount_point = root_mount_point + raw_mount_point
-    
+
     # Ensure that the created directory has the correct SELinux context on
     # SELinux-enabled systems.
 

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -312,7 +312,8 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         try: # <--- You need this line!
             for s in btrfs_subvolumes:
                 if not s["subvolume"]:
-                    continue # not throwing exception
+                    err(f"Btrfs subvolume not defined {device}",am) # hard relying on the config 
+                    # continue # not throwing exception, ignoring invalid config
                 sub_path = setup_dir + s["subvolume"]
                 if not os.path.exists(sub_path):
                     os.makedirs(os.path.dirname(sub_path), exist_ok=True)

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -317,6 +317,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     # Find the root subvolume (usually /@)
     root_sub = next((s for s in btrfs_subvolumes if s["mountPoint"] == "/"), None)
     if not root_sub:
+        libcalamares.utils.warning(f"Btrfs root subvolume (/) not found")
         raise Exception("Btrfs root subvolume (/) not found!")
     # Mount the specific @ subvolume to the root mount point
     root_opts = f"subvol={root_sub['subvolume']},{mount_options_string}"

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -339,8 +339,8 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     # insert the root subvolume into global storage
     libcalamares.globalstorage.insert("btrfsRootSubvolume", root_sub['subvolume'])
 
+    # Mount raw partition to create subvolumes
     with tempfile.TemporaryDirectory(prefix="calam-btrfs-") as setup_dir:
-        # Mount raw partition to create subvolumes
         am.append(setup_dir)
         if libcalamares.utils.mount(device, setup_dir, fstype, "defaults") != 0:
             err(f"Cannot mount btrfs for subvolume creation {device}", am)

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -244,7 +244,16 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     # SELinux-enabled systems.
 
     os.makedirs(mount_point, exist_ok=True)
-    os.chmod(mount_point, 0o755)  # Ensure root/pacman can write here
+
+    # Hardening: Only chmod physical paths. 
+    # Skip virtuals (sys, proc, dev, run) and unformatted partitions.
+    is_virtual = any(raw_mount_point.startswith(v) for v in ["/sys", "/proc", "/dev", "/run"])
+    if not is_virtual and fstype != "unformatted":
+        try:
+            os.chmod(mount_point, 0o755)
+        except OSError as e:
+            libcalamares.utils.warning(f"Could not chmod {mount_point}: {e}")
+
     try:
         subprocess.call(['chcon', '--reference=' + raw_mount_point, mount_point])
     except FileNotFoundError as e:

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -338,7 +338,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
 
     # Store created list in global storage so it can be used in the fstab module
     libcalamares.globalstorage.insert("btrfsSubvolumes", btrfs_subvolumes)
-    # Fstab uses btrfsRootSubvolume to inject subvol=@ into generic / entry
+    # Fstab uses btrfsRootSubvolume to inject subvol=/@ into generic / entry
     libcalamares.globalstorage.insert("btrfsRootSubvolume", root_sub['subvolume'])
 
     # Mount raw partition to create subvolumes

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -294,6 +294,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     if not (fstype == "btrfs" and raw_mount_point == '/'):
         if libcalamares.utils.mount(device, mount_point, fstype, mount_options_string) != 0:
             libcalamares.utils.warning(f"Cannot mount {device}")
+            raise Exception(f"Cannot mount {device}")
 
         return
 

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -232,8 +232,14 @@ def mount_zfs(root_mount_point, partition):
         except subprocess.CalledProcessError:
             raise ZfsException(_("Failed to set zfs mountpoint"))
 
+def err(error_message, active_mounts):
+    for tmp_dir in sorted(active_mounts, reverse=True):
+        if os.path.ismount(tmp_dir):
+            if subprocess.call(["umount", "-v", tmp_dir]) != 0:
+                subprocess.call(["umount", "-v", "-l", tmp_dir])
+    raise Exception(error_message)
 
-def mount_partition(root_mount_point, partition, partitions, mount_options, mount_options_list, efi_location):
+def mount_partition(root_mount_point, partition, partitions, mount_options, mount_options_list, efi_location, active_mounts):
     """
     Do a single mount of @p partition inside @p root_mount_point.
 
@@ -243,6 +249,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     :param mount_options: The mount options from the config file
     :param mount_options_list: A list of options for each mountpoint to be placed in global storage for future modules
     :param efi_location: A string holding the location of the EFI partition or None
+    :param active_mounts A list of strings
     :return:
     """
     # Create mount point with `+` rather than `os.path.join()` because
@@ -252,7 +259,8 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         return
 
     mount_point = root_mount_point + raw_mount_point
-
+    am = active_mounts
+    am.append(mount_point)
     # Ensure that the created directory has the correct SELinux context on
     # SELinux-enabled systems.
 
@@ -272,7 +280,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         is_boot = raw_mount_point in ["/boot", "/boot/efi"]
         # Block if: not a boot path, OR ntfs/ext2, OR exfat on UEFI
         if not is_boot or fstype in ["ntfs", "ext2"] or (fstype == "exfat" and efi_location):
-            raise Exception(f"Unsupported partition with {fstype} on {raw_mount_point}")
+            err(f"Unsupported partition with {fstype} on {raw_mount_point}",am)
             # return (fstab still sees the partition)
         fstype = "vfat" if fstype != "exfat" else "exfat"
 
@@ -289,7 +297,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     # Standard mount for everything EXCEPT Btrfs root (this catches other btrfs partitions)
     if not (fstype == "btrfs" and raw_mount_point == '/'):
         if libcalamares.utils.mount(device, mount_point, fstype, mount_options_string) != 0:
-            raise Exception(f"Cannot mount {device}")
+            err(f"Cannot mount {device}",am)
 
         return
 
@@ -299,8 +307,9 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
 
     with tempfile.TemporaryDirectory(prefix="calam-btrfs-") as setup_dir:
         # Mount raw partition to create subvolumes
+        am.append(setup_dir)
         if libcalamares.utils.mount(device, setup_dir, fstype, "defaults") != 0:
-            raise Exception(f"Cannot mount btrfs for subvolume creation {device}")
+            err(f"Cannot mount btrfs for subvolume creation {device}",am)
         try: # <--- You need this line!
             for s in btrfs_subvolumes:
                 sub_path = setup_dir + s["subvolume"]
@@ -312,22 +321,22 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         finally:
             if os.path.ismount(setup_dir):
                 subprocess.check_call(["umount", "-v", setup_dir])
-            else:
-                raise Exception(f"Critical error: {setup_dir} is unexpectedly not mounted.")
+            if setup_dir in am:
+                am.remove(setup_dir)
 
     # Find the root subvolume (usually /@)
     root_sub = next((s for s in btrfs_subvolumes if s["mountPoint"] == "/"), None)
     if not root_sub:
-        raise Exception(f"Btrfs root subvolume (/) not found!")
+        err(f"Btrfs root subvolume (/) not found!",am)
 
     # Mount the specific @ subvolume to the root mount point
     if root_sub['subvolume']:
         root_opts = f"subvol={root_sub['subvolume']},{mount_options_string}"
     else:
-        raise Exception(f"Configuration error: root subvolume not defined")
+        err(f"root subvolume not defined",am)
 
     if libcalamares.utils.mount(device, root_mount_point, fstype, root_opts) != 0:
-        raise Exception(f"Failed to mount root subvolume {device}")
+        err(f"Failed to mount root subvolume {device}",am)
 
     # Step 3: Mount remaining subvolumes (like /home)
     for s in btrfs_subvolumes:
@@ -339,7 +348,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
             # This tells Linux: "Put this specific subvolume here"
             sub_opts = f"subvol={s['subvolume']},{mount_options_string}"
         else:
-            raise Exception("Configuration error: subvolume not defined")
+            err("subvolume not defined",am)
 
         # This builds the path INSIDE your new root
         sub_path = root_mount_point + s["mountPoint"]
@@ -348,7 +357,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         if libcalamares.utils.mount(device, sub_path, fstype, sub_opts) == 0:
             mount_options_list.append({"mountpoint": s["mountPoint"], "option_string": mount_options_string})
         else:
-            raise Exception(f"Failed to mount subvolume {s['subvolume']}")
+            err(f"Failed to mount subvolume {s['subvolume']}",am)
 
 
 def enable_swap_partition(devices):
@@ -402,24 +411,24 @@ def run():
     # under /tmp, we make sure /tmp is mounted before the partition)
     # mount_options_list will be inserted into global storage for use in fstab later
     mount_options_list = []
-
+    active_mounts = []
     # 4. Phase One: Physical (Lexical Depth Sort: / before /var)  
     physical = [p for p in partitions if "mountPoint" in p and p["mountPoint"]]
     physical.sort(key=lambda x: x["mountPoint"])
 
     try:
         for p in physical:
-            mount_partition(root_mount_point, p, partitions, mount_options, mount_options_list, efi_location)
+            mount_partition(root_mount_point, p, partitions, mount_options, mount_options_list, efi_location, active_mounts)
          
         # 5. Phase Two: Bind/Virtual (After Btrfs subvolumes exist)
         extra = [p for p in extra_mounts if "mountPoint" in p and p["mountPoint"]]
         extra.sort(key=lambda x: x["mountPoint"])
 
         for p in extra:
-            mount_partition(root_mount_point, p, partitions, mount_options, mount_options_list, efi_location)
+            mount_partition(root_mount_point, p, partitions, mount_options, mount_options_list, efi_location, active_mounts)
 
-    except ZfsException as ze:
-        return _("zfs mounting error"), ze.message
+    except Exception as e:
+        err(str(e), active_mounts)
 
     libcalamares.globalstorage.insert("rootMountPoint", root_mount_point)
     libcalamares.globalstorage.insert("mountOptionsList", mount_options_list)

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -244,7 +244,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     # SELinux-enabled systems.
 
     os.makedirs(mount_point, exist_ok=True)
-
+    os.chmod(mount_point, 0o755)  # Ensure root/pacman can write here
     try:
         subprocess.call(['chcon', '--reference=' + raw_mount_point, mount_point])
     except FileNotFoundError as e:

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -174,12 +174,9 @@ def mount_zfs(root_mount_point, partition, am):
 
     :param root_mount_point: The absolute path to the root of the install
     :param partition: The partition map from global storage for this partition
-    :param am A list of strings
+    :param am: crash helper
     :return:
     """
-    # Move this to the top of mount_zfs
-    if not libcalamares.globalstorage.value("zfsDatasets"):
-        err("Manual ZFS unsupported. Use 'Erase Disk'.", am)
     # Get the list of zpools from global storage
     zfs_pool_list = libcalamares.globalstorage.value("zfsPoolInfo")
     if not zfs_pool_list:
@@ -231,6 +228,7 @@ def mount_zfs(root_mount_point, partition, am):
             except subprocess.CalledProcessError:
                 raise ZfsException(_("Failed to set zfs mountpoint"))
     else:
+        err("Manual ZFS unsupported. Use 'Erase Disk'.", am)
         try:
             libcalamares.utils.host_env_process_output(["zfs", "mount", pool_name + '/' + ds_name])
         except subprocess.CalledProcessError:

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -340,64 +340,49 @@ def enable_swap_partition(devices):
 
 
 def run():
-    """
-    Mount all the partitions from GlobalStorage and from the job configuration.
-    Partitions are mounted in-lexical-order of their mountPoint.
-    """
+    partitions = libcalamares.globalstorage.value("partitions")
+    if not partitions:
+        libcalamares.utils.warning("partitions is empty")
+        return (_("Configuration Error"), _("No partitions defined."))
 
-    partitions = libcalamares.globalstorage.value("partitions")
+    # 1. Restore Swap Activation (Physical swap first)
+    claimed_swap = [p for p in partitions if p["fs"] == "linuxswap" and p.get("claimed", False)]
+    swap_devices = [p["device"] if p["fsName"] == "linuxswap" else 
+                    "/dev/mapper/" + p["luksMapperName"] for p in claimed_swap]
+    enable_swap_partition(swap_devices)
 
-    if not partitions:
-        libcalamares.utils.warning("partitions is empty, {!s}".format(partitions))
-        return (_("Configuration Error"),
-                _("No partitions are defined for <pre>{!s}</pre> to use.").format("mount"))
+    # 2. Setup Environment
+    root_mount_point = tempfile.mkdtemp(prefix="calamares-root-")
+    mount_options = libcalamares.job.configuration.get("mountOptions")
+    extra_mounts = libcalamares.job.configuration.get("extraMounts") or []
+    mount_options_list = []
 
-    # Find existing swap partitions that are part of the installation and enable them now
-    claimed_swap_partitions = [p for p in partitions if p["fs"] == "linuxswap" and p.get("claimed", False)]
-    plain_swap = [p for p in claimed_swap_partitions if p["fsName"] == "linuxswap"]
-    luks_swap = [p for p in claimed_swap_partitions if p["fsName"] == "luks" or p["fsName"] == "luks2"]
-    swap_devices = [p["device"] for p in plain_swap] + ["/dev/mapper/" + p["luksMapperName"] for p in luks_swap]
+    # 3. EFI Logic (Filtered properly)
+    efi_location = None
+    if libcalamares.globalstorage.value("firmwareType") == "efi":
+        efi_location = libcalamares.globalstorage.value("efiSystemPartition")
+    else:
+        extra_mounts = [m for m in extra_mounts if not m.get("efi")]
 
-    enable_swap_partition(swap_devices)
+    # 4. Phase One: Physical (Depth Sort: / before /var) 
+    physical = [p for p in partitions if "mountPoint" in p and p["mountPoint"]]
+    physical.sort(key=lambda x: x["mountPoint"].count('/'))
 
-    root_mount_point = tempfile.mkdtemp(prefix="calamares-root-")
+    try:
+        for p in physical:
+            mount_partition(root_mount_point, p, partitions, mount_options, mount_options_list, efi_location)
+        
+        # 5. Phase Two: Bind/Virtual (After Btrfs subvolumes exist)
+        extra = [p for p in extra_mounts if "mountPoint" in p and p["mountPoint"]]
+        extra.sort(key=lambda x: x["mountPoint"].count('/'))
 
-    # Get the mountOptions, if this is None, that is OK and will be handled later
-    mount_options = libcalamares.job.configuration.get("mountOptions")
+        for p in extra:
+            mount_partition(root_mount_point, p, partitions, mount_options, mount_options_list, efi_location)
 
-    # Guard against missing keys (generally a sign that the config file is bad)
-    extra_mounts = libcalamares.job.configuration.get("extraMounts") or []
-    if not extra_mounts:
-        libcalamares.utils.warning("No extra mounts defined. Does mount.conf exist?")
+    except ZfsException as ze:
+        return _("zfs mounting error"), ze.message
 
-    efi_location = None
-    if libcalamares.globalstorage.value("firmwareType") == "efi":
-        efi_location = libcalamares.globalstorage.value("efiSystemPartition")
-    else:
-        for mount in extra_mounts:
-            if mount.get("efi", None) is True:
-                extra_mounts.remove(mount)
-
-    # Add extra mounts to the partitions list and sort by mount points.
-    # This way, we ensure / is mounted before the rest, and every mount point
-    # is created on the right partition (e.g. if a partition is to be mounted
-    # under /tmp, we make sure /tmp is mounted before the partition)
-    mountable_partitions = [p for p in partitions + extra_mounts if "mountPoint" in p and p["mountPoint"]]
-    mountable_partitions.sort(key=lambda x: x["mountPoint"])
-
-    # mount_options_list will be inserted into global storage for use in fstab later
-    mount_options_list = []
-    try:
-        for partition in mountable_partitions:
-            mount_partition(root_mount_point, partition, partitions, mount_options, mount_options_list, efi_location)
-    except ZfsException as ze:
-        return _("zfs mounting error"), ze.message
-
-    if not mount_options_list:
-        libcalamares.utils.warning("No mount options defined, {!s} partitions, {!s} mountable".format(len(partitions), len(mountable_partitions)))
-
-    libcalamares.globalstorage.insert("rootMountPoint", root_mount_point)
-    libcalamares.globalstorage.insert("mountOptionsList", mount_options_list)
-
-    # Remember the extra mounts for the unpackfs module
-    libcalamares.globalstorage.insert("extraMounts", extra_mounts)
+    # 6. Global Storage Persistence
+    libcalamares.globalstorage.insert("rootMountPoint", root_mount_point)
+    libcalamares.globalstorage.insert("mountOptionsList", mount_options_list)
+    libcalamares.globalstorage.insert("extraMounts", extra_mounts)

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -228,7 +228,7 @@ def mount_zfs(root_mount_point, partition, am):
             except subprocess.CalledProcessError:
                 raise ZfsException(_("Failed to set zfs mountpoint"))
     else:
-        err("Manual ZFS unsupported. Use 'Erase Disk'.", am)
+        err("Manual ZFS unsupported. Use 'Erase Disk'.", am) # this doesnt install correctly
         try:
             libcalamares.utils.host_env_process_output(["zfs", "mount", pool_name + '/' + ds_name])
         except subprocess.CalledProcessError:

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -305,7 +305,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     if not (fstype == "btrfs" and raw_mount_point == '/'):
         if libcalamares.utils.mount(device, mount_point, fstype, mount_options_string) != 0:
             err(f"Cannot mount {device}", am)
-        # check only relevant partitions for ghost data
+        # Verify that the install target is empty
         if not is_virtual and raw_mount_point not in ["/home", "/srv", "/boot", "/boot/efi"]:
             ignored_metadata = [
                 "lost+found", ".Trash-1000", "$RECYCLE.BIN", 

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -360,7 +360,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     if root_sub['subvolume']:
         root_opts = f"subvol={root_sub['subvolume']},{mount_options_string}"
     else:
-        err(f"root subvolume not defined", am)
+        err(f"Root subvolume not defined", am)
 
     if libcalamares.utils.mount(device, root_mount_point, fstype, root_opts) != 0:
         err(f"Failed to mount root subvolume {device}", am)

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -272,7 +272,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         pass
 
     fstype = partition.get("fs", "").lower()
-    if fstype == "unformatted": # why is this here
+    if fstype == "unformatted":
         return
 
     device = partition["device"]

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -166,7 +166,8 @@ def get_btrfs_subvolumes(partitions):
         libcalamares.globalstorage.insert("btrfsSwapSubvol", swap_subvol)
 
     return btrfs_subvolumes
-    
+
+
 def mount_zfs(root_mount_point, partition):
     """ Mounts a zfs partition at @p root_mount_point
 

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -295,7 +295,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     with tempfile.TemporaryDirectory(prefix="calam-btrfs-") as setup_dir:
         # Mount raw partition to create subvolumes
         libcalamares.utils.mount(device, setup_dir, fstype, "defaults")
-        try:
+        try: # <--- You need this line!
             for s in btrfs_subvolumes:
                 sub_path = setup_dir + s["subvolume"]
                 if not os.path.exists(sub_path):

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -315,7 +315,8 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
                     if s["mountPoint"] == "/root":
                         os.chmod(sub_path, 0o750)
         finally:
-            subprocess.check_call(["umount", "-v", setup_dir])
+            if os.path.ismount(setup_dir):
+                subprocess.check_call(["umount", "-v", setup_dir])
 
     # Find the root subvolume (usually /@)
     root_sub = next((s for s in btrfs_subvolumes if s["mountPoint"] == "/"), None)

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -324,8 +324,20 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
 
     # Btrfs Setup
     btrfs_subvolumes = get_btrfs_subvolumes(partitions)
+    # Ensure every entry has a subvolume name
+    for s in btrfs_subvolumes:
+        if not s.get("mountPoint") or not s.get("subvolume"):
+            err(f"Btrfs config error: entry missing mountPoint or subvolume name", am)
+
+    # Ensure root subolume with mountpoint / exists 
+    root_sub = next((s for s in btrfs_subvolumes if s["mountPoint"] == "/"), None)
+    if not root_sub:
+        err("Btrfs config error: root subvolume not found", am)
+
     # Store created list in global storage so it can be used in the fstab module
     libcalamares.globalstorage.insert("btrfsSubvolumes", btrfs_subvolumes)
+    # insert the root subvolume into global storage
+    libcalamares.globalstorage.insert("btrfsRootSubvolume", root_sub['subvolume'])
 
     with tempfile.TemporaryDirectory(prefix="calam-btrfs-") as setup_dir:
         # Mount raw partition to create subvolumes
@@ -333,9 +345,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         if libcalamares.utils.mount(device, setup_dir, fstype, "defaults") != 0:
             err(f"Cannot mount btrfs for subvolume creation {device}", am)
         try:
-            for s in btrfs_subvolumes: # Pre-validation
-                if not s["subvolume"]:
-                    err(f"Btrfs subvolume not defined {device}", am) # instead of continue
+            for s in btrfs_subvolumes:
                 sub_path = setup_dir + s["subvolume"]
                 if os.path.exists(sub_path):
                     err(f"Subvolume {s['subvolume']} already exists on {device}. Please backup and format or use /home or /srv for this partition.", am)
@@ -352,33 +362,19 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
             if setup_dir in am:
                 am.remove(setup_dir)
 
-    # Find the root subvolume (usually /@)
-    root_sub = next((s for s in btrfs_subvolumes if s["mountPoint"] == "/"), None)
-    if not root_sub:
-        err(f"Btrfs root subvolume not found!", am)
-
-    # Mount the specific @ subvolume to the root mount point
-    if root_sub['subvolume']:
-        root_opts = f"subvol={root_sub['subvolume']},{mount_options_string}"
-    else:
-        err(f"Root subvolume not defined", am)
+    # Mount the specific @ root subvolume
+    root_opts = f"subvol={root_sub['subvolume']},{mount_options_string}"
 
     if libcalamares.utils.mount(device, root_mount_point, fstype, root_opts) != 0:
         err(f"Failed to mount root subvolume {device}", am)
-
-    # insert the root subvolume into global storage
-    libcalamares.globalstorage.insert("btrfsRootSubvolume", root_sub['subvolume'])
 
     # Mount remaining subvolumes
     for s in btrfs_subvolumes:
         if s["mountPoint"] == "/":
             continue
 
-        if s['subvolume']:
-            # This tells Linux: "Put this specific subvolume here"
-            sub_opts = f"subvol={s['subvolume']},{mount_options_string}"
-        else:
-            err("subvolume not defined", am) # not mounting entire filesystem
+        # This tells Linux: "Put this specific subvolume here"
+        sub_opts = f"subvol={s['subvolume']},{mount_options_string}"
 
         # This builds the path INSIDE your new root
         sub_path = root_mount_point + s["mountPoint"]

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -260,8 +260,6 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
 
     mount_point = root_mount_point + raw_mount_point
 
-    am = active_mounts
-    am.append(mount_point)
     # Ensure that the created directory has the correct SELinux context on
     # SELinux-enabled systems.
 
@@ -279,8 +277,10 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     if fstype == "unformatted":
         return
 
-
+    am = active_mounts
+    am.append(mount_point)
     device = partition["device"]
+
     if fstype in ["fat16", "fat32", "exfat", "ntfs", "ext2"]:
         is_boot = raw_mount_point in ["/boot", "/boot/efi"]
         # Block if: not a boot path, OR ntfs/ext2/exfat

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -282,7 +282,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     am.append(mount_point)
     device = partition["device"]
 
-    # Block if: not a boot path, OR fat16/ntfs/ext2/exfat
+    # Only allow fat32 on boot path
     if fstype in ["fat16", "fat32", "ntfs", "ext2", "exfat"]:
         is_boot = raw_mount_point in ["/boot", "/boot/efi"]
         if not (is_boot and fstype == "fat32"):

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -269,7 +269,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     btrfs_subvolumes = get_btrfs_subvolumes(partitions)
     libcalamares.globalstorage.insert("btrfsSubvolumes", btrfs_subvolumes)
 
-    # Step 1: Private side-mount to create subvolumes
+    # Step 1: Create subvolumes via a private "backdoor" mount
     with tempfile.TemporaryDirectory(prefix="calam-btrfs-") as setup_dir:
         libcalamares.utils.mount(device, setup_dir, fstype, "defaults")
         try:  # <--- You need this line!
@@ -277,12 +277,14 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
                 if s["subvolume"]:
                     os.makedirs(setup_dir + os.path.dirname(s["subvolume"]), exist_ok=True)
                     subprocess.check_call(["btrfs", "subvolume", "create", setup_dir + s["subvolume"]])
-        finally: # <--- This matches the 'try'
-            # Manually release the SSD so Python can delete setup_dir
+        finally:
+            # UNMOUNT 1: Close the "backdoor" so the temp directory can be cleaned up
+            # We must clear this so we can remount using the '@' subvolume specifically.
             subprocess.check_call(["umount", "-v", setup_dir])
-    # Step 2: Swap raw mount for @ subvolume mount
+    
+    # Step 2: Prepare for the real mount
     try:
-        #if os.path.ismount(root_mount_point):
+        # UNMOUNT 2: Remove the "flat" partition mount Calamares created earlier.
         subprocess.call(["umount", "-l", root_mount_point])
     except Exception:
         pass

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -343,7 +343,8 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
                     os.chmod(sub_path, 0o750)
         finally:
             if os.path.ismount(setup_dir):
-                subprocess.check_call(["umount", "-v", setup_dir])
+                # Use call to avoid raising a new error during cleanup
+                subprocess.call(["umount", "-v", setup_dir])
             if setup_dir in am:
                 am.remove(setup_dir)
 

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -260,11 +260,8 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
 
     try:
         subprocess.call(['chcon', '--reference=' + raw_mount_point, mount_point])
-    except FileNotFoundError as e:
-        libcalamares.utils.warning(str(e))
-    except OSError:
-        libcalamares.utils.error("Cannot run 'chcon' normally.")
-        raise
+    except:
+        pass
 
     fstype = partition.get("fs", "").lower()
     if fstype == "unformatted":
@@ -275,7 +272,6 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         is_boot = raw_mount_point in ["/boot", "/boot/efi"]
         # Block if: not a boot path, OR ntfs/ext2, OR exfat on UEFI
         if not is_boot or fstype in ["ntfs", "ext2"] or (fstype == "exfat" and efi_location):
-            libcalamares.utils.warning(f"Unsupported partition with {fstype} on {raw_mount_point}")
             raise Exception(f"Unsupported partition with {fstype} on {raw_mount_point}")
             # return (fstab still sees the partition)
         fstype = "vfat" if fstype != "exfat" else "exfat"
@@ -293,7 +289,6 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     # Standard mount for everything EXCEPT Btrfs root (this catches other btrfs partitions)
     if not (fstype == "btrfs" and raw_mount_point == '/'):
         if libcalamares.utils.mount(device, mount_point, fstype, mount_options_string) != 0:
-            libcalamares.utils.warning(f"Cannot mount {device}")
             raise Exception(f"Cannot mount {device}")
 
         return
@@ -305,7 +300,6 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     with tempfile.TemporaryDirectory(prefix="calam-btrfs-") as setup_dir:
         # Mount raw partition to create subvolumes
         if libcalamares.utils.mount(device, setup_dir, fstype, "defaults") != 0:
-            libcalamares.utils.warning(f"Cannot mount btrfs for subvolume creation {device}")
             raise Exception(f"Cannot mount btrfs for subvolume creation {device}")
         try: # <--- You need this line!
             for s in btrfs_subvolumes:
@@ -319,24 +313,20 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
             if os.path.ismount(setup_dir):
                 subprocess.check_call(["umount", "-v", setup_dir])
             else:
-                libcalamares.utils.warning(f"Critical error: {setup_dir} is unexpectedly not mounted.")
                 raise Exception(f"Critical error: {setup_dir} is unexpectedly not mounted.")
 
     # Find the root subvolume (usually /@)
     root_sub = next((s for s in btrfs_subvolumes if s["mountPoint"] == "/"), None)
     if not root_sub:
-        libcalamares.utils.warning(f"Btrfs root subvolume (/) not found")
         raise Exception(f"Btrfs root subvolume (/) not found!")
 
     # Mount the specific @ subvolume to the root mount point
     if root_sub['subvolume']:
         root_opts = f"subvol={root_sub['subvolume']},{mount_options_string}"
     else:
-        libcalamares.utils.warning(f"Configuration error: root subvolume not defined")
         raise Exception(f"Configuration error: root subvolume not defined")
 
     if libcalamares.utils.mount(device, root_mount_point, fstype, root_opts) != 0:
-        libcalamares.utils.warning(f"Failed to mount root subvolume {device}")
         raise Exception(f"Failed to mount root subvolume {device}")
 
     # Step 3: Mount remaining subvolumes (like /home)
@@ -349,7 +339,6 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
             # This tells Linux: "Put this specific subvolume here"
             sub_opts = f"subvol={s['subvolume']},{mount_options_string}"
         else:
-            libcalamares.utils.warning("Configuration error: subvolume not defined")
             raise Exception("Configuration error: subvolume not defined")
 
         # This builds the path INSIDE your new root
@@ -359,7 +348,6 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         if libcalamares.utils.mount(device, sub_path, fstype, sub_opts) == 0:
             mount_options_list.append({"mountpoint": s["mountPoint"], "option_string": mount_options_string})
         else:
-            libcalamares.utils.warning(f"Failed to mount subvolume {s['subvolume']}")
             raise Exception(f"Failed to mount subvolume {s['subvolume']}")
 
 

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -252,6 +252,10 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         return
 
     mount_point = root_mount_point + raw_mount_point
+
+    # Ensure that the created directory has the correct SELinux context on
+    # SELinux-enabled systems.
+
     os.makedirs(mount_point, exist_ok=True)
     fstype = partition.get("fs", "").lower()
 

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -293,6 +293,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         device = os.path.join("/dev/mapper", partition["luksMapperName"])
 
     if fstype == "zfs":
+        # If mountpoint is not / pacstrap missing mkinitcpio hooks 
         mount_zfs(root_mount_point, partition)
         return
 

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -327,13 +327,13 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         if libcalamares.utils.mount(device, setup_dir, fstype, "defaults") != 0:
             err(f"Cannot mount btrfs for subvolume creation {device}", am)
         try: # <--- You need this line!
-            for s in btrfs_subvolumes: # 1. Pre-validation
+            for s in btrfs_subvolumes: # Pre-validation
                 if not s["subvolume"]:
                     err(f"Btrfs subvolume not defined {device}", am) # instead of continue
                 sub_path = setup_dir + s["subvolume"]
                 if os.path.exists(sub_path):
                     err(f"Subvolume {s['subvolume']} already exists on {device}. Please format.", am)
-            for s in btrfs_subvolumes: # 2. Execution
+            for s in btrfs_subvolumes:
                 sub_path = setup_dir + s["subvolume"]
                 os.makedirs(os.path.dirname(sub_path), exist_ok=True)
                 subprocess.check_call(["btrfs", "subvolume", "create", sub_path])

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -373,10 +373,8 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         if s["mountPoint"] == "/":
             continue
 
-        # This tells Linux: "Put this specific subvolume here"
-        sub_opts = f"subvol={s['subvolume']},{mount_options_string}"
-
-        # This builds the path INSIDE your new root
+        # Prepare subvolume mount options and target mount point
+        sub_opts = f"subvol={s['subvolume']},{mount_options_string}" 
         sub_path = root_mount_point + s["mountPoint"]
         os.makedirs(sub_path, exist_ok=True)
 

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -307,7 +307,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
             err(f"Cannot mount {device}", am)
         # check only relevant partitions for ghost data
         if not is_virtual and raw_mount_point not in ["/home", "/srv", "/boot", "/boot/efi"]:
-            contents = [f for f in os.listdir(mount_point) if f != "lost+found"]
+            contents = [f for f in os.listdir(mount_point) if f not in ["lost+found", ".Trash-1000", "System Volume Information"]]
             if contents:
                 err(f"Partition {device} has data. Please format.", am)
 

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -279,6 +279,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     if fstype == "unformatted":
         return
 
+
     device = partition["device"]
     if fstype in ["fat16", "fat32", "exfat", "ntfs", "ext2"]:
         is_boot = raw_mount_point in ["/boot", "/boot/efi"]

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -245,6 +245,8 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     :param efi_location: A string holding the location of the EFI partition or None
     :return:
     """
+    # Create mount point with `+` rather than `os.path.join()` because
+    # `partition["mountPoint"]` starts with a '/'.
     raw_mount_point = partition["mountPoint"]
     if not raw_mount_point:
         return

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -361,6 +361,9 @@ def run():
     root_mount_point = tempfile.mkdtemp(prefix="calamares-root-")
     mount_options = libcalamares.job.configuration.get("mountOptions")
     extra_mounts = libcalamares.job.configuration.get("extraMounts") or []
+    if not extra_mounts:
+        libcalamares.utils.warning("No extra mounts defined. Does mount.conf exist?")
+
     mount_options_list = []
 
     # 3. EFI Logic (Filtered properly)

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -300,6 +300,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     # Step 3: Mount remaining subvolumes (like /home)
     for s in btrfs_subvolumes:
         if s["mountPoint"] == "/":
+            libcalamares.globalstorage.insert("btrfsRootSubvolume", s["subvolume"])
             continue
             
         # This builds the path INSIDE your new root

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -278,7 +278,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     device = partition["device"]
     if fstype in ["fat16", "fat32", "exfat", "ntfs", "ext2"]:
         is_boot = raw_mount_point in ["/boot", "/boot/efi"]
-        # Block if: not a boot path, OR ntfs/ext2, OR exfat on UEFI
+        # Block if: not a boot path, OR ntfs/ext2/exfat
         if not is_boot or fstype in ["ntfs", "ext2", "exfat"]:
             err(f"Unsupported partition with {fstype} on {raw_mount_point}",am)
         fstype = "vfat" if fstype != "exfat" else "exfat"

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -333,6 +333,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     if root_sub['subvolume']:
         root_opts = f"subvol={root_sub['subvolume']},{mount_options_string}"
     else:
+        libcalamares.utils.warning(f"Configuration error: root subvolume not defined")
         raise Exception(f"Configuration error: root subvolume not defined")
 
     if libcalamares.utils.mount(device, root_mount_point, fstype, root_opts) != 0:

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -143,8 +143,10 @@ def get_btrfs_subvolumes(partitions):
     # Filter: Skip subvolume if it IS a partition OR is INSIDE a partition
     btrfs_subvolumes = [
         s for s in btrfs_subvolumes 
-        if not any(s["mountPoint"] == m or s["mountPoint"].startswith(m + "/") 
-                   for m in non_root_partition_mounts)
+        if s["mountPoint"] == "/" or not any(
+            m and (s["mountPoint"] == m or s["mountPoint"].startswith(m + "/"))
+            for m in non_root_partition_mounts
+        )
     ]
 
     # If we have a swap **file**, give it a separate subvolume.

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -442,7 +442,7 @@ def run():
     mount_options_list = []
     active_mounts = []
 
-    # Lexical Depth Sort: mount before sub-paths  
+    # Lexical Sort: mount / before sub-paths  
     physical = [p for p in partitions if "mountPoint" in p and p["mountPoint"]]
     physical.sort(key=lambda x: x["mountPoint"])
 

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -279,7 +279,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     if fstype in ["fat16", "fat32", "exfat", "ntfs", "ext2"]:
         is_boot = raw_mount_point in ["/boot", "/boot/efi"]
         # Block if: not a boot path, OR ntfs/ext2, OR exfat on UEFI
-        if not is_boot or fstype in ["ntfs", "ext2"] or (fstype == "exfat" and efi_location):
+        if not is_boot or fstype in ["ntfs", "ext2", "exfat"]:
             err(f"Unsupported partition with {fstype} on {raw_mount_point}",am)
         fstype = "vfat" if fstype != "exfat" else "exfat"
 

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -126,30 +126,26 @@ def get_mount_options(filesystem, mount_options, partition, efi_location = None)
     else:
         return "defaults"
 
-
 def get_btrfs_subvolumes(partitions):
     """
-    Gets the job-configuration for btrfs subvolumes, or if there is
-    none given, returns a default configuration that matches
-    the setup (/ and /home) from before configurability was introduced.
-
-    @param partitions
-        The partitions (from the partitioning module) that will exist on disk.
-        This is used to filter out subvolumes that don't need to be created
-        because they get a dedicated partition instead.
+    Gets the job-configuration for btrfs subvolumes.
     """
     btrfs_subvolumes = libcalamares.job.configuration.get("btrfsSubvolumes", None)
-    # Warn if there's no configuration at all, and empty configurations are
-    # replaced by a simple root-only layout.
     if btrfs_subvolumes is None:
         libcalamares.utils.warning("No configuration for btrfsSubvolumes")
     if not btrfs_subvolumes:
         btrfs_subvolumes = [dict(mountPoint="/", subvolume="/@"), dict(mountPoint="/home", subvolume="/@home")]
 
-    # Filter out the subvolumes which have a dedicated partition
+    # Identify dedicated partitions (excluding root)
     non_root_partition_mounts = [m for m in [p.get("mountPoint", None) for p in partitions] if
                                  m is not None and m != '/']
-    btrfs_subvolumes = list(filter(lambda s: s["mountPoint"] not in non_root_partition_mounts, btrfs_subvolumes))
+
+    # Filter: Skip subvolume if it IS a partition OR is INSIDE a partition
+    btrfs_subvolumes = [
+        s for s in btrfs_subvolumes 
+        if not any(s["mountPoint"] == m or s["mountPoint"].startswith(m + "/") 
+                   for m in non_root_partition_mounts)
+    ]
 
     # If we have a swap **file**, give it a separate subvolume.
     swap_choice = libcalamares.globalstorage.value("partitionChoices")
@@ -159,8 +155,7 @@ def get_btrfs_subvolumes(partitions):
         libcalamares.globalstorage.insert("btrfsSwapSubvol", swap_subvol)
 
     return btrfs_subvolumes
-
-
+    
 def mount_zfs(root_mount_point, partition):
     """ Mounts a zfs partition at @p root_mount_point
 
@@ -337,6 +332,7 @@ def enable_swap_partition(devices):
             libcalamares.utils.host_env_process_output(["swapon", d])
     except subprocess.CalledProcessError:
         libcalamares.utils.warning(f"Failed to enable swap for devices: {devices}")
+
 
 def run():
     partitions = libcalamares.globalstorage.value("partitions")

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -320,7 +320,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     # Mount the specific @ subvolume to the root mount point
     root_opts = f"subvol={root_sub['subvolume']},{mount_options_string}"
     if libcalamares.utils.mount(device, root_mount_point, fstype, root_opts) != 0:
-        libcalamares.utils.warning(f"Cannot mount root subvolume {device}")
+        raise Exception(f"Failed to mount root subvolume {device}")
 
     # Step 3: Mount remaining subvolumes (like /home)
     for s in btrfs_subvolumes:

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -383,7 +383,7 @@ def run():
     # mount_options_list will be inserted into global storage for use in fstab later
     mount_options_list = []
 
-    # 4. Phase One: Physical (Depth Sort: / before /var)  
+    # 4. Phase One: Physical (Lexical Depth Sort: / before /var)  
     physical = [p for p in partitions if "mountPoint" in p and p["mountPoint"]]
     physical.sort(key=lambda x: x["mountPoint"])
 

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -289,7 +289,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     mount_options_string = get_mount_options(fstype, mount_options, partition, efi_location)
     mount_options_list.append({"mountpoint": raw_mount_point, "option_string": mount_options_string})
     
-    # Standard mount for everything EXCEPT Btrfs root
+    # Standard mount for everything EXCEPT Btrfs root (this catches other btrfs partitions)
     if not (fstype == "btrfs" and raw_mount_point == '/'):
         if libcalamares.utils.mount(device, mount_point, fstype, mount_options_string) != 0:
             libcalamares.utils.warning(f"Cannot mount {device}")
@@ -316,11 +316,19 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
 
     # Find the root subvolume (usually /@)
     root_sub = next((s for s in btrfs_subvolumes if s["mountPoint"] == "/"), None)
-
+    if not root_sub:
+        raise Exception("Btrfs root subvolume (/) not found!")
     # Mount the specific @ subvolume to the root mount point
     root_opts = f"subvol={root_sub['subvolume']},{mount_options_string}"
     if libcalamares.utils.mount(device, root_mount_point, fstype, root_opts) != 0:
+        libcalamares.utils.warning(f"Failed to mount root subvolume {device}")
         raise Exception(f"Failed to mount root subvolume {device}")
+
+    # 1. Identify swap subvolume
+    swap_subvol = libcalamares.job.configuration.get("btrfsSwapSubvol", "/@swap")    
+    # 2. Only fetch swap options if the subvolume actually exists in the list
+    has_swap = any(s["subvolume"] == swap_subvol for s in btrfs_subvolumes)
+    swap_options = get_mount_options("btrfs_swap", mount_options, partition) if has_swap else None
 
     # Step 3: Mount remaining subvolumes (like /home)
     for s in btrfs_subvolumes:
@@ -328,14 +336,22 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
             libcalamares.globalstorage.insert("btrfsRootSubvolume", s["subvolume"])
             continue
 
+        # Swap-specific options vs. regular Btrfs subvolume flags
+        chosen_options = swap_options if (has_swap and s['subvolume'] == swap_subvol) else mount_options_string
+        # Handle "breadcrumb" logic for empty subvolume names
+        if s['subvolume']:
+            # This tells Linux: "Put this specific subvolume here"
+            sub_opts = f"subvol={s['subvolume']},{chosen_options}"
+        else:
+            # Mounting the entire filesystem (if subvol is missing in config?)
+            sub_opts = chosen_options
+
         # This builds the path INSIDE your new root
         sub_path = root_mount_point + s["mountPoint"]
         os.makedirs(sub_path, exist_ok=True)
-        # This tells Linux: "Put this specific subvolume here"
-        sub_opts = f"subvol={s['subvolume']},{mount_options_string}"
 
         if libcalamares.utils.mount(device, sub_path, fstype, sub_opts) == 0:
-            mount_options_list.append({"mountpoint": s["mountPoint"], "option_string": mount_options_string})
+            mount_options_list.append({"mountpoint": s["mountPoint"], "option_string": chosen_options})
         else:
             libcalamares.utils.warning(f"Failed to mount subvolume {s['subvolume']}")
 
@@ -413,7 +429,7 @@ def run():
         return _("zfs mounting error"), ze.message
 
     if not mount_options_list:
-        libcalamares.utils.warning("No mount options defined, {!s} partitions, {!s} mountable".format(len(partitions), len(mountable_partitions)))
+        libcalamares.utils.warning("No mount options defined, {!s} partitions, {!s} mountable, {!s} extraMounts".format(len(partitions), len(physical), len(extra)))
 
     libcalamares.globalstorage.insert("rootMountPoint", root_mount_point)
     libcalamares.globalstorage.insert("mountOptionsList", mount_options_list)

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -282,8 +282,8 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     am.append(mount_point)
     device = partition["device"]
 
+    # Block if: not a boot path, OR fat16/ntfs/ext2/exfat
     if fstype in ["fat16", "fat32", "ntfs", "ext2", "exfat"]:
-        # Block if: not a boot path, OR fat16/ntfs/ext2/exfat
         is_boot = raw_mount_point in ["/boot", "/boot/efi"]
         if not (is_boot and fstype == "fat32"):
             err(f"Unsupported {fstype} on {raw_mount_point}", am)

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -323,6 +323,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
 
     # Btrfs Setup
     btrfs_subvolumes = get_btrfs_subvolumes(partitions)
+    # Store created list in global storage so it can be used in the fstab module
     libcalamares.globalstorage.insert("btrfsSubvolumes", btrfs_subvolumes)
 
     with tempfile.TemporaryDirectory(prefix="calam-btrfs-") as setup_dir:
@@ -341,6 +342,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
                 sub_path = setup_dir + s["subvolume"]
                 os.makedirs(os.path.dirname(sub_path), exist_ok=True)
                 subprocess.check_call(["btrfs", "subvolume", "create", sub_path])
+                # Set secure permissions for /root subvolume (750 instead of default 755)
                 if s["mountPoint"] == "/root":
                     os.chmod(sub_path, 0o750)
         finally:
@@ -366,6 +368,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     # Mount remaining subvolumes
     for s in btrfs_subvolumes:
         if s["mountPoint"] == "/":
+            # insert the root subvolume into global storage
             libcalamares.globalstorage.insert("btrfsRootSubvolume", s["subvolume"])
             continue
 

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -169,13 +169,17 @@ def get_btrfs_subvolumes(partitions):
     return btrfs_subvolumes
 
 
-def mount_zfs(root_mount_point, partition):
+def mount_zfs(root_mount_point, partition, am):
     """ Mounts a zfs partition at @p root_mount_point
 
     :param root_mount_point: The absolute path to the root of the install
     :param partition: The partition map from global storage for this partition
+    :param am A list of strings
     :return:
     """
+    # Move this to the top of mount_zfs
+    if not libcalamares.globalstorage.value("zfsDatasets"):
+        err("Manual ZFS unsupported. Use 'Erase Disk'.", am)
     # Get the list of zpools from global storage
     zfs_pool_list = libcalamares.globalstorage.value("zfsPoolInfo")
     if not zfs_pool_list:
@@ -227,11 +231,10 @@ def mount_zfs(root_mount_point, partition):
             except subprocess.CalledProcessError:
                 raise ZfsException(_("Failed to set zfs mountpoint"))
     else:
-        #try:
-            #libcalamares.utils.host_env_process_output(["zfs", "mount", pool_name + '/' + ds_name])
-        #except subprocess.CalledProcessError:
-            #raise ZfsException(_("Failed to set zfs mountpoint"))
-        err("ZFS is only supported on root (/).",am)
+        try:
+            libcalamares.utils.host_env_process_output(["zfs", "mount", pool_name + '/' + ds_name])
+        except subprocess.CalledProcessError:
+            raise ZfsException(_("Failed to set zfs mountpoint"))
 
 def err(error_message, active_mounts):
     for tmp_dir in sorted(active_mounts, reverse=True):
@@ -292,7 +295,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         device = os.path.join("/dev/mapper", partition["luksMapperName"])
 
     if fstype == "zfs":
-        mount_zfs(root_mount_point, partition)
+        mount_zfs(root_mount_point, partition, am)
         return
 
     mount_options_string = get_mount_options(fstype, mount_options, partition, efi_location)

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -329,6 +329,11 @@ def enable_swap_partition(devices):
 
 
 def run():
+    """
+    Mount all the partitions from GlobalStorage and from the job configuration.
+    Partitions are mounted in-lexical-order of their mountPoint.
+    """
+
     partitions = libcalamares.globalstorage.value("partitions")
     if not partitions:
         libcalamares.utils.warning("partitions is empty")

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -281,7 +281,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         # Block if: not a boot path, OR ntfs/ext2/exfat
         if not is_boot or fstype in ["ntfs", "ext2", "exfat"]:
             err(f"Unsupported partition with {fstype} on {raw_mount_point}",am)
-        fstype = "vfat" if fstype != "exfat" else "exfat"
+        fstype = "vfat"
 
     if "luksMapperName" in partition:
         device = os.path.join("/dev/mapper", partition["luksMapperName"])

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -301,6 +301,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     mount_options_string = get_mount_options(fstype, mount_options, partition, efi_location)
     mount_options_list.append({"mountpoint": raw_mount_point, "option_string": mount_options_string})
     is_virtual = any(raw_mount_point.startswith(v) for v in ["/sys", "/proc", "/dev", "/run"])
+
     # Standard mount for everything EXCEPT Btrfs root (this catches other btrfs partitions)
     if not (fstype == "btrfs" and raw_mount_point == '/'):
         if libcalamares.utils.mount(device, mount_point, fstype, mount_options_string) != 0:

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -340,34 +340,26 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         libcalamares.utils.warning(f"Failed to mount root subvolume {device}")
         raise Exception(f"Failed to mount root subvolume {device}")
 
-    # 1. Identify swap subvolume
-    swap_subvol = libcalamares.job.configuration.get("btrfsSwapSubvol", "/@swap")    
-    # 2. Only fetch swap options if the subvolume actually exists in the list
-    has_swap = any(s["subvolume"] == swap_subvol for s in btrfs_subvolumes)
-    swap_options = get_mount_options("btrfs_swap", mount_options, partition) if has_swap else None
-
     # Step 3: Mount remaining subvolumes (like /home)
     for s in btrfs_subvolumes:
         if s["mountPoint"] == "/":
             libcalamares.globalstorage.insert("btrfsRootSubvolume", s["subvolume"])
             continue
 
-        # Swap-specific options vs. regular Btrfs subvolume flags
-        chosen_options = swap_options if (has_swap and s['subvolume'] == swap_subvol) else mount_options_string
         # Handle "breadcrumb" logic for empty subvolume names
         if s['subvolume']:
             # This tells Linux: "Put this specific subvolume here"
-            sub_opts = f"subvol={s['subvolume']},{chosen_options}"
+            sub_opts = f"subvol={s['subvolume']},{mount_options_string}"
         else:
-            # Mounting the entire filesystem (if subvol is missing in config?)
-            sub_opts = chosen_options
+            libcalamares.utils.warning("Configuration error: subvolume not defined")
+            raise Exception("Configuration error: subvolume not defined")
 
         # This builds the path INSIDE your new root
         sub_path = root_mount_point + s["mountPoint"]
         os.makedirs(sub_path, exist_ok=True)
 
         if libcalamares.utils.mount(device, sub_path, fstype, sub_opts) == 0:
-            mount_options_list.append({"mountpoint": s["mountPoint"], "option_string": chosen_options})
+            mount_options_list.append({"mountpoint": s["mountPoint"], "option_string": mount_options_string})
         else:
             libcalamares.utils.warning(f"Failed to mount subvolume {s['subvolume']}")
             raise Exception(f"Failed to mount subvolume {s['subvolume']}")

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -292,7 +292,8 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     root_opts = f"subvol={root_sub['subvolume']},{mount_options_string}"
     if libcalamares.utils.mount(device, root_mount_point, fstype, root_opts) != 0:
         raise Exception(f"Failed to mount root subvolume {root_sub['subvolume']}")
-
+    # Add this after the root subvolume mount succeeds:
+    mount_options_list.append({"mountpoint": "/", "option_string": root_opts})  
     # Step 3: Mount remaining subvolumes (like /home)
     for s in btrfs_subvolumes:
         if s["mountPoint"] == "/":
@@ -306,8 +307,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         
         if libcalamares.utils.mount(device, sub_path, fstype, sub_opts) != 0:
             libcalamares.utils.warning(f"Failed to mount subvolume {s['subvolume']}")
-    # Add this after the root subvolume mount succeeds:
-    mount_options_list.append({"mountpoint": "/", "option_string": root_opts})    
+  
 def enable_swap_partition(devices):
     try:
         for d in devices:

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -317,6 +317,9 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         finally:
             if os.path.ismount(setup_dir):
                 subprocess.check_call(["umount", "-v", setup_dir])
+            else:
+                libcalamares.utils.warning(f"Critical error: {setup_dir} is unexpectedly not mounted.")
+                raise Exception(f"Critical error: {setup_dir} is unexpectedly not mounted.")
 
     # Find the root subvolume (usually /@)
     root_sub = next((s for s in btrfs_subvolumes if s["mountPoint"] == "/"), None)

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -308,6 +308,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     if not (fstype == "btrfs" and raw_mount_point == '/'):
         if libcalamares.utils.mount(device, mount_point, fstype, mount_options_string) != 0:
             err(f"Cannot mount {device}", am)
+
         # Verify that the install target is empty
         if not is_virtual and raw_mount_point not in ["/home", "/srv", "/boot", "/boot/efi"]:
             ignored_metadata = [

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -319,7 +319,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
 
         return
 
-    # Btrfs Root "Magic Trick" Logic
+    # Btrfs Root
     btrfs_subvolumes = get_btrfs_subvolumes(partitions)
     libcalamares.globalstorage.insert("btrfsSubvolumes", btrfs_subvolumes)
 
@@ -328,7 +328,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         am.append(setup_dir)
         if libcalamares.utils.mount(device, setup_dir, fstype, "defaults") != 0:
             err(f"Cannot mount btrfs for subvolume creation {device}", am)
-        try: # <--- You need this line!
+        try:
             for s in btrfs_subvolumes: # Pre-validation
                 if not s["subvolume"]:
                     err(f"Btrfs subvolume not defined {device}", am) # instead of continue

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -319,7 +319,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
 
         return
 
-    # Btrfs Root
+    # Btrfs Setup
     btrfs_subvolumes = get_btrfs_subvolumes(partitions)
     libcalamares.globalstorage.insert("btrfsSubvolumes", btrfs_subvolumes)
 

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -303,8 +303,14 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     
     # Standard mount for everything EXCEPT Btrfs root (this catches other btrfs partitions)
     if not (fstype == "btrfs" and raw_mount_point == '/'):
+        # 1. Perform the mount
         if libcalamares.utils.mount(device, mount_point, fstype, mount_options_string) != 0:
-            err(f"Cannot mount {device}",am)
+            err(f"Cannot mount {device}", am)
+        # 2. Check for "ghost" data immediately after
+        if raw_mount_point not in ["/home", "/srv", "/boot", "/boot/efi"]:
+            contents = [f for f in os.listdir(mount_point) if f != "lost+found"]
+            if contents:
+                err(f"Partition {device} has data. Please format!", am)
 
         return
 
@@ -316,11 +322,11 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         # Mount raw partition to create subvolumes
         am.append(setup_dir)
         if libcalamares.utils.mount(device, setup_dir, fstype, "defaults") != 0:
-            err(f"Cannot mount btrfs for subvolume creation {device}",am)
+            err(f"Cannot mount btrfs for subvolume creation {device}", am)
         try: # <--- You need this line!
             for s in btrfs_subvolumes: # 1. Pre-validation: Is the coast clear?
                 if not s["subvolume"]:
-                    err(f"Btrfs subvolume not defined {device}",am) # instead of continue
+                    err(f"Btrfs subvolume not defined {device}", am) # instead of continue
                 sub_path = setup_dir + s["subvolume"]
                 if os.path.exists(sub_path): # if this exists user is at fault
                     err(f"Subvolume {s['subvolume']} already exists on {device}. Please format the partition to avoid a messy installation.", am)
@@ -339,16 +345,16 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     # Find the root subvolume (usually /@)
     root_sub = next((s for s in btrfs_subvolumes if s["mountPoint"] == "/"), None)
     if not root_sub:
-        err(f"Btrfs root subvolume (/) not found!",am)
+        err(f"Btrfs root subvolume (/) not found!", am)
 
     # Mount the specific @ subvolume to the root mount point
     if root_sub['subvolume']:
         root_opts = f"subvol={root_sub['subvolume']},{mount_options_string}"
     else:
-        err(f"root subvolume not defined",am)
+        err(f"root subvolume not defined", am)
 
     if libcalamares.utils.mount(device, root_mount_point, fstype, root_opts) != 0:
-        err(f"Failed to mount root subvolume {device}",am)
+        err(f"Failed to mount root subvolume {device}", am)
 
     # Step 3: Mount remaining subvolumes (like /home)
     for s in btrfs_subvolumes:
@@ -360,7 +366,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
             # This tells Linux: "Put this specific subvolume here"
             sub_opts = f"subvol={s['subvolume']},{mount_options_string}"
         else:
-            err("subvolume not defined",am) # instead of mounting entire filesystem
+            err("subvolume not defined", am) # instead of mounting entire filesystem
 
         # This builds the path INSIDE your new root
         sub_path = root_mount_point + s["mountPoint"]
@@ -369,7 +375,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         if libcalamares.utils.mount(device, sub_path, fstype, sub_opts) == 0:
             mount_options_list.append({"mountpoint": s["mountPoint"], "option_string": mount_options_string})
         else:
-            err(f"Failed to mount subvolume {s['subvolume']}",am)
+            err(f"Failed to mount subvolume {s['subvolume']}", am)
 
 
 def enable_swap_partition(devices):

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -338,51 +338,50 @@ def enable_swap_partition(devices):
     except subprocess.CalledProcessError:
         libcalamares.utils.warning(f"Failed to enable swap for devices: {devices}")
 
-
 def run():
-    partitions = libcalamares.globalstorage.value("partitions")
-    if not partitions:
-        libcalamares.utils.warning("partitions is empty")
-        return (_("Configuration Error"), _("No partitions defined."))
+    partitions = libcalamares.globalstorage.value("partitions")
+    if not partitions:
+        libcalamares.utils.warning("partitions is empty")
+        return (_("Configuration Error"), _("No partitions defined."))
 
-    # 1. Restore Swap Activation (Physical swap first)
-    claimed_swap = [p for p in partitions if p["fs"] == "linuxswap" and p.get("claimed", False)]
-    swap_devices = [p["device"] if p["fsName"] == "linuxswap" else 
-                    "/dev/mapper/" + p["luksMapperName"] for p in claimed_swap]
-    enable_swap_partition(swap_devices)
+    # 1. Restore Swap Activation (Physical swap first)
+    claimed_swap = [p for p in partitions if p["fs"] == "linuxswap" and p.get("claimed", False)]
+    swap_devices = [p["device"] if p["fsName"] == "linuxswap" else 
+                    "/dev/mapper/" + p["luksMapperName"] for p in claimed_swap]
+    enable_swap_partition(swap_devices)
 
-    # 2. Setup Environment
-    root_mount_point = tempfile.mkdtemp(prefix="calamares-root-")
-    mount_options = libcalamares.job.configuration.get("mountOptions")
-    extra_mounts = libcalamares.job.configuration.get("extraMounts") or []
-    mount_options_list = []
+    # 2. Setup Environment
+    root_mount_point = tempfile.mkdtemp(prefix="calamares-root-")
+    mount_options = libcalamares.job.configuration.get("mountOptions")
+    extra_mounts = libcalamares.job.configuration.get("extraMounts") or []
+    mount_options_list = []
 
-    # 3. EFI Logic (Filtered properly)
-    efi_location = None
-    if libcalamares.globalstorage.value("firmwareType") == "efi":
-        efi_location = libcalamares.globalstorage.value("efiSystemPartition")
-    else:
-        extra_mounts = [m for m in extra_mounts if not m.get("efi")]
+    # 3. EFI Logic (Filtered properly)
+    efi_location = None
+    if libcalamares.globalstorage.value("firmwareType") == "efi":
+        efi_location = libcalamares.globalstorage.value("efiSystemPartition")
+    else:
+        extra_mounts = [m for m in extra_mounts if not m.get("efi")]
 
-    # 4. Phase One: Physical (Depth Sort: / before /var) 
-    physical = [p for p in partitions if "mountPoint" in p and p["mountPoint"]]
-    physical.sort(key=lambda x: x["mountPoint"].count('/'))
+    # 4. Phase One: Physical (Depth Sort: / before /var)  
+    physical = [p for p in partitions if "mountPoint" in p and p["mountPoint"]]
+    physical.sort(key=lambda x: x["mountPoint"].count('/'))
 
-    try:
-        for p in physical:
-            mount_partition(root_mount_point, p, partitions, mount_options, mount_options_list, efi_location)
-        
-        # 5. Phase Two: Bind/Virtual (After Btrfs subvolumes exist)
-        extra = [p for p in extra_mounts if "mountPoint" in p and p["mountPoint"]]
-        extra.sort(key=lambda x: x["mountPoint"].count('/'))
+    try:
+        for p in physical:
+            mount_partition(root_mount_point, p, partitions, mount_options, mount_options_list, efi_location)
+         
+        # 5. Phase Two: Bind/Virtual (After Btrfs subvolumes exist)
+        extra = [p for p in extra_mounts if "mountPoint" in p and p["mountPoint"]]
+        extra.sort(key=lambda x: x["mountPoint"].count('/'))
 
-        for p in extra:
-            mount_partition(root_mount_point, p, partitions, mount_options, mount_options_list, efi_location)
+        for p in extra:
+            mount_partition(root_mount_point, p, partitions, mount_options, mount_options_list, efi_location)
 
-    except ZfsException as ze:
-        return _("zfs mounting error"), ze.message
+    except ZfsException as ze:
+        return _("zfs mounting error"), ze.message
 
-    # 6. Global Storage Persistence
-    libcalamares.globalstorage.insert("rootMountPoint", root_mount_point)
-    libcalamares.globalstorage.insert("mountOptionsList", mount_options_list)
-    libcalamares.globalstorage.insert("extraMounts", extra_mounts)
+    # 6. Global Storage Persistence
+    libcalamares.globalstorage.insert("rootMountPoint", root_mount_point)
+    libcalamares.globalstorage.insert("mountOptionsList", mount_options_list)
+    libcalamares.globalstorage.insert("extraMounts", extra_mounts)

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -343,7 +343,6 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
                     os.chmod(sub_path, 0o750)
         finally:
             if os.path.ismount(setup_dir):
-                # Use call to avoid raising a new error during cleanup
                 subprocess.call(["umount", "-v", setup_dir])
             if setup_dir in am:
                 am.remove(setup_dir)

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -293,9 +293,6 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         device = os.path.join("/dev/mapper", partition["luksMapperName"])
 
     if fstype == "zfs":
-        if raw_mount_point != '/':
-            # Pacstrap failure mkinitcpio hook missing
-            err("Manual ZFS unsupported. Use 'Erase Disk'.", am)
         mount_zfs(root_mount_point, partition)
         return
 

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -315,7 +315,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
                 ]
             contents = [f for f in os.listdir(mount_point) if f not in ignored_metadata]
             if contents:
-                err(f"Device {device} at {raw_mount_point} has data. Please backup and format or use /home or /srv for this partition.", am)
+                err(f"Device {device} at {raw_mount_point} not empty. Please backup and format or use /home or /srv for this partition.", am)
 
         return
 

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -329,7 +329,6 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         raise Exception("Btrfs root subvolume (/) not found!")
 
     # Mount the specific @ subvolume to the root mount point
-    # Handle empty subvolume name for the root mount
     if root_sub['subvolume']:
         root_opts = f"subvol={root_sub['subvolume']},{mount_options_string}"
     else:

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -317,7 +317,9 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
                 ]
             contents = [f for f in os.listdir(mount_point) if f not in ignored_metadata]
             if contents:
-                err(f"Device {device} at {raw_mount_point} not empty. Please backup and format or use /home or /srv for this partition.", am)
+                err((
+                    f"Device {device} at {raw_mount_point} not empty. "
+                    "Only /home or /srv allowed."), am)
 
         return
 
@@ -348,7 +350,9 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
             for s in btrfs_subvolumes:
                 sub_path = setup_dir + s["subvolume"]
                 if os.path.exists(sub_path):
-                    err(f"Subvolume {s['subvolume']} already exists on {device}. Please backup and format or use /home or /srv for this partition.", am)
+                    err((
+                        f"Subvolume {s['subvolume']} exists on {device}. "
+                        "Only /home or /srv allowed."), am)
             for s in btrfs_subvolumes:
                 sub_path = setup_dir + s["subvolume"]
                 os.makedirs(os.path.dirname(sub_path), exist_ok=True)

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -307,10 +307,10 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         if libcalamares.utils.mount(device, mount_point, fstype, mount_options_string) != 0:
             err(f"Cannot mount {device}", am)
         # 2. Check for "ghost" data immediately after
-        if raw_mount_point not in ["/home", "/srv", "/boot", "/boot/efi"]:
-            contents = [f for f in os.listdir(mount_point) if f != "lost+found"]
-            if contents:
-                err(f"Partition {device} has data. Please format.", am)
+        #if raw_mount_point not in ["/home", "/srv", "/boot", "/boot/efi"]:
+            #contents = [f for f in os.listdir(mount_point) if f != "lost+found"]
+            #if contents:
+                #err(f"Partition {device} has data. Please format.", am)
 
         return
 

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -365,11 +365,12 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     if libcalamares.utils.mount(device, root_mount_point, fstype, root_opts) != 0:
         err(f"Failed to mount root subvolume {device}", am)
 
-    # Mount remaining subvolumes
+    # insert the root subvolume into global storage
+    libcalamares.globalstorage.insert("btrfsRootSubvolume", root_sub['subvolume'])
+
+    # Mount subvolumes
     for s in btrfs_subvolumes:
         if s["mountPoint"] == "/":
-            # insert the root subvolume into global storage
-            libcalamares.globalstorage.insert("btrfsRootSubvolume", s["subvolume"])
             continue
 
         if s['subvolume']:

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -264,6 +264,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         fstype = "vfat"
 
     device = partition["device"]
+    
     if "luksMapperName" in partition:
         device = os.path.join("/dev/mapper", partition["luksMapperName"])
 

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -221,32 +221,14 @@ def mount_zfs(root_mount_point, partition):
 
 
 def mount_partition(root_mount_point, partition, partitions, mount_options, mount_options_list, efi_location):
-    """
-    Do a single mount of @p partition inside @p root_mount_point.
-
-    :param root_mount_point: A string containing the root of the install
-    :param partition: A dict containing information about the partition
-    :param partitions: The full list of partitions used to filter out btrfs subvols which have duplicate mountpoints
-    :param mount_options: The mount options from the config file
-    :param mount_options_list: A list of options for each mountpoint to be placed in global storage for future modules
-    :param efi_location: A string holding the location of the EFI partition or None
-    :return:
-    """
-    # Create mount point with `+` rather than `os.path.join()` because
-    # `partition["mountPoint"]` starts with a '/'.
     raw_mount_point = partition["mountPoint"]
     if not raw_mount_point:
         return
 
     mount_point = root_mount_point + raw_mount_point
-
-    # Ensure that the created directory has the correct SELinux context on
-    # SELinux-enabled systems.
-
     os.makedirs(mount_point, exist_ok=True)
     fstype = partition.get("fs", "").lower()
-    # Hardening: Only chmod physical paths. 
-    # Skip virtuals (sys, proc, dev, run) and unformatted partitions.
+
     is_virtual = any(raw_mount_point.startswith(v) for v in ["/sys", "/proc", "/dev", "/run"])
     if not is_virtual and fstype != "unformatted":
         try:
@@ -256,84 +238,66 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
 
     try:
         subprocess.call(['chcon', '--reference=' + raw_mount_point, mount_point])
-    except FileNotFoundError as e:
-        libcalamares.utils.warning(str(e))
-    except OSError:
-        libcalamares.utils.error("Cannot run 'chcon' normally.")
-        raise
+    except:
+        pass
 
     if fstype == "unformatted":
         return
-
-    if fstype == "fat16" or fstype == "fat32":
+    if fstype in ["fat16", "fat32"]:
         fstype = "vfat"
 
     device = partition["device"]
-
     if "luksMapperName" in partition:
         device = os.path.join("/dev/mapper", partition["luksMapperName"])
 
     if fstype == "zfs":
         mount_zfs(root_mount_point, partition)
-    else:  # fstype == "zfs"
-        mount_options_string = get_mount_options(fstype, mount_options, partition, efi_location)
-        if libcalamares.utils.mount(device,
-                                    mount_point,
-                                    fstype,
-                                    mount_options_string) != 0:
-            libcalamares.utils.warning("Cannot mount {}".format(device))
+        return
+
+    mount_options_string = get_mount_options(fstype, mount_options, partition, efi_location)
+
+    # Standard mount for everything EXCEPT Btrfs root
+    if not (fstype == "btrfs" and raw_mount_point == '/'):
+        if libcalamares.utils.mount(device, mount_point, fstype, mount_options_string) != 0:
+            libcalamares.utils.warning(f"Cannot mount {device}")
         mount_options_list.append({"mountpoint": raw_mount_point, "option_string": mount_options_string})
+        return
 
-    # Special handling for btrfs subvolumes. Create the subvolumes listed in mount.conf
-    if fstype == "btrfs" and partition["mountPoint"] == '/':
-        # Root has been mounted to btrfs volume -> create subvolumes from configuration
-        btrfs_subvolumes = get_btrfs_subvolumes(partitions)
+    # Btrfs Root "Magic Trick" Logic
+    btrfs_subvolumes = get_btrfs_subvolumes(partitions)
+    libcalamares.globalstorage.insert("btrfsSubvolumes", btrfs_subvolumes)
 
-        # Store created list in global storage so it can be used in the fstab module
-        libcalamares.globalstorage.insert("btrfsSubvolumes", btrfs_subvolumes)
-        # Create the subvolumes that are in the completed list
+    # Step 1: Private side-mount to create subvolumes
+    with tempfile.TemporaryDirectory(prefix="calam-btrfs-") as setup_dir:
+        libcalamares.utils.mount(device, setup_dir, fstype, "defaults")
         for s in btrfs_subvolumes:
-            if not s["subvolume"]:
-                continue
-            os.makedirs(root_mount_point + os.path.dirname(s["subvolume"]), exist_ok=True)
-            subprocess.check_call(["btrfs", "subvolume", "create",
-                                   root_mount_point + s["subvolume"]])
-            # Set secure permissions for /root subvolume (750 instead of default 755)
-            if s["mountPoint"] == "/root":
-                os.chmod(root_mount_point + s["subvolume"], 0o750)
+            if s["subvolume"]:
+                os.makedirs(setup_dir + os.path.dirname(s["subvolume"]), exist_ok=True)
+                subprocess.check_call(["btrfs", "subvolume", "create", setup_dir + s["subvolume"]])
 
-            if s["mountPoint"] == "/":
-                # insert the root subvolume into global storage
-                libcalamares.globalstorage.insert("btrfsRootSubvolume", s["subvolume"])
-        subprocess.check_call(["umount", "-v", root_mount_point])
+    # Step 2: Swap raw mount for @ subvolume mount
+    subprocess.check_call(["umount", "-v", root_mount_point])
+    
+    root_sub = next((s for s in btrfs_subvolumes if s["mountPoint"] == "/"), None)
+    if not root_sub:
+        raise Exception("No root (/) subvolume defined!")
 
-        device = partition["device"]
+    root_opts = f"subvol={root_sub['subvolume']},{mount_options_string}"
+    if libcalamares.utils.mount(device, root_mount_point, fstype, root_opts) != 0:
+        raise Exception(f"Failed to mount root subvolume {root_sub['subvolume']}")
 
-        if "luksMapperName" in partition:
-            device = os.path.join("/dev/mapper", partition["luksMapperName"])
-
-        # Mount the subvolumes
-        swap_subvol = libcalamares.job.configuration.get("btrfsSwapSubvol", "/@swap")
-        for s in btrfs_subvolumes:
-            if s['subvolume'] == swap_subvol:
-                mount_option_no_subvol = get_mount_options("btrfs_swap", mount_options, partition)
-            else:
-                mount_option_no_subvol = get_mount_options(fstype, mount_options, partition)
-
-            # Only add subvol= argument if we are not mounting the entire filesystem
-            if s['subvolume']:
-                mount_option = f"subvol={s['subvolume']},{mount_option_no_subvol}"
-            else:
-                mount_option = mount_option_no_subvol
-            subvolume_mountpoint = mount_point[:-1] + s['mountPoint']
-            mount_options_list.append({"mountpoint": s['mountPoint'], "option_string": mount_option_no_subvol})
-            if libcalamares.utils.mount(device,
-                                        subvolume_mountpoint,
-                                        fstype,
-                                        mount_option) != 0:
-                libcalamares.utils.warning("Cannot mount {}".format(device))
-
-
+    # Step 3: Mount remaining subvolumes (like /home)
+    for s in btrfs_subvolumes:
+        if s["mountPoint"] == "/":
+            continue
+        
+        sub_path = root_mount_point + s["mountPoint"]
+        os.makedirs(sub_path, exist_ok=True)
+        sub_opts = f"subvol={s['subvolume']},{mount_options_string}"
+        
+        if libcalamares.utils.mount(device, sub_path, fstype, sub_opts) != 0:
+            libcalamares.utils.warning(f"Failed to mount subvolume {s['subvolume']}")
+            
 def enable_swap_partition(devices):
     try:
         for d in devices:

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -302,7 +302,9 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
 
     with tempfile.TemporaryDirectory(prefix="calam-btrfs-") as setup_dir:
         # Mount raw partition to create subvolumes
-        libcalamares.utils.mount(device, setup_dir, fstype, "defaults")
+        if libcalamares.utils.mount(device, setup_dir, fstype, "defaults") != 0:
+            libcalamares.utils.warning(f"Cannot mount btrfs for subvolume creation {device}")
+            raise Exception(f"Cannot mount btrfs for subvolume creation {device}")
         try: # <--- You need this line!
             for s in btrfs_subvolumes:
                 sub_path = setup_dir + s["subvolume"]

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -128,7 +128,14 @@ def get_mount_options(filesystem, mount_options, partition, efi_location = None)
 
 def get_btrfs_subvolumes(partitions):
     """
-    Gets the job-configuration for btrfs subvolumes.
+    Gets the job-configuration for btrfs subvolumes, or if there is
+    none given, returns a default configuration that matches
+    the setup (/ and /home) from before configurability was introduced.
+
+    @param partitions
+        The partitions (from the partitioning module) that will exist on disk.
+        This is used to filter out subvolumes that don't need to be created
+        because they get a dedicated partition instead.
     """
     btrfs_subvolumes = libcalamares.job.configuration.get("btrfsSubvolumes", None)
     if btrfs_subvolumes is None:

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -284,6 +284,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         is_boot = raw_mount_point in ["/boot", "/boot/efi"]
         # Block if: not a boot path, OR ntfs/ext2/exfat
         if not is_boot or fstype in ["ntfs", "ext2", "exfat"]:
+            # instead of returning we avoid the fstab problem
             err(f"Unsupported partition with {fstype} on {raw_mount_point}",am)
         fstype = "vfat"
 

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -312,8 +312,8 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         try: # <--- You need this line!
             for s in btrfs_subvolumes:
                 if not s["subvolume"]:
-                    err(f"Btrfs subvolume not defined {device}",am) # hard relying on the config 
-                    ### continue ### not throwing exception, ignoring invalid config
+                    err(f"Btrfs subvolume not defined {device}",am) # relying on mount.conf 
+                    ### continue ### ignoring invalid config
                 sub_path = setup_dir + s["subvolume"]
                 if not os.path.exists(sub_path):
                     os.makedirs(os.path.dirname(sub_path), exist_ok=True)

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -318,12 +318,14 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         if libcalamares.utils.mount(device, setup_dir, fstype, "defaults") != 0:
             err(f"Cannot mount btrfs for subvolume creation {device}",am)
         try: # <--- You need this line!
-            for s in btrfs_subvolumes:
+            for s in btrfs_subvolumes: # 1. Pre-validation: Is the coast clear?
                 if not s["subvolume"]:
                     err(f"Btrfs subvolume not defined {device}",am) # instead of continue
                 sub_path = setup_dir + s["subvolume"]
                 if os.path.exists(sub_path): # if this exists user is at fault
                     err(f"Subvolume {s['subvolume']} already exists. Please format the partition to avoid a messy installation.", am)
+            for s in btrfs_subvolumes: # 2. Execution: All checks passed ("Luft ist rein")
+                sub_path = setup_dir + s["subvolume"]
                 os.makedirs(os.path.dirname(sub_path), exist_ok=True)
                 subprocess.check_call(["btrfs", "subvolume", "create", sub_path])
                 if s["mountPoint"] == "/root":

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -251,6 +251,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
 
     mount_options_string = get_mount_options(fstype, mount_options, partition, efi_location)
     mount_options_list.append({"mountpoint": raw_mount_point, "option_string": mount_options_string})
+    
     # Standard mount for everything EXCEPT Btrfs root
     if not (fstype == "btrfs" and raw_mount_point == '/'):
         if libcalamares.utils.mount(device, mount_point, fstype, mount_options_string) != 0:

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -322,11 +322,12 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
                 if not s["subvolume"]:
                     err(f"Btrfs subvolume not defined {device}",am) # instead of continue
                 sub_path = setup_dir + s["subvolume"]
-                if not os.path.exists(sub_path): # if this exists user is at fault
-                    os.makedirs(os.path.dirname(sub_path), exist_ok=True)
-                    subprocess.check_call(["btrfs", "subvolume", "create", sub_path])
-                    if s["mountPoint"] == "/root":
-                        os.chmod(sub_path, 0o750)
+                if os.path.exists(sub_path): # if this exists user is at fault
+                    err(f"Subvolume {s['subvolume']} already exists. Please format the partition to avoid a messy installation.", am)
+                os.makedirs(os.path.dirname(sub_path), exist_ok=True)
+                subprocess.check_call(["btrfs", "subvolume", "create", sub_path])
+                if s["mountPoint"] == "/root":
+                    os.chmod(sub_path, 0o750)
         finally:
             if os.path.ismount(setup_dir):
                 subprocess.check_call(["umount", "-v", setup_dir])

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -311,7 +311,6 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         
         if libcalamares.utils.mount(device, sub_path, fstype, sub_opts) == 0:
             mount_options_list.append({"mountpoint": raw_mount_point, "option_string": mount_options_string})
-            libcalamares.utils.warning(f"Failed to mount subvolume {s['subvolume']}")
         else:
             libcalamares.utils.warning(f"Failed to mount subvolume {s['subvolume']}")
             

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -316,7 +316,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     # Mount the specific @ subvolume to the root mount point
     root_opts = f"subvol={root_sub['subvolume']},{mount_options_string}"
     if libcalamares.utils.mount(device, root_mount_point, fstype, root_opts) != 0:
-        raise Exception(f"Failed to mount root subvolume")
+        libcalamares.utils.warning(f"Cannot mount root subvolume {device}")
         
     # Step 3: Mount remaining subvolumes (like /home)
     for s in btrfs_subvolumes:

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -266,7 +266,8 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     fstype = partition.get("fs", "").lower()
     if fstype == "unformatted":
         return
-    if fstype in ["fat16", "fat32"]:
+
+    if fstype == "fat16" or fstype == "fat32":
         fstype = "vfat"
 
     device = partition["device"]

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -252,13 +252,13 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         return
 
     mount_point = root_mount_point + raw_mount_point
+
     device = partition["device"]
     
     # Ensure that the created directory has the correct SELinux context on
     # SELinux-enabled systems.
 
     os.makedirs(mount_point, exist_ok=True)
-    fstype = partition.get("fs", "").lower()
 
     try:
         subprocess.call(['chcon', '--reference=' + raw_mount_point, mount_point])
@@ -268,6 +268,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         libcalamares.utils.error("Cannot run 'chcon' normally.")
         raise
 
+    fstype = partition.get("fs", "").lower()
     if fstype == "unformatted":
         return
 

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -311,6 +311,8 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
             err(f"Cannot mount btrfs for subvolume creation {device}",am)
         try: # <--- You need this line!
             for s in btrfs_subvolumes:
+                if not s["subvolume"]:
+                    continue
                 sub_path = setup_dir + s["subvolume"]
                 if not os.path.exists(sub_path):
                     os.makedirs(os.path.dirname(sub_path), exist_ok=True)

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -257,13 +257,13 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     # SELinux-enabled systems.
 
     os.makedirs(mount_point, exist_ok=True)
-    fstype = partition.get("fs", "").lower()
 
     try:
         subprocess.call(['chcon', '--reference=' + raw_mount_point, mount_point])
     except:
         pass
 
+    fstype = partition.get("fs", "").lower()
     if fstype == "unformatted":
         return
     if fstype in ["fat16", "fat32"]:

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -252,19 +252,13 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         return
 
     mount_point = root_mount_point + raw_mount_point
-
+    device = partition["device"]
+    
     # Ensure that the created directory has the correct SELinux context on
     # SELinux-enabled systems.
 
     os.makedirs(mount_point, exist_ok=True)
     fstype = partition.get("fs", "").lower()
-
-    is_virtual = any(raw_mount_point.startswith(v) for v in ["/sys", "/proc", "/dev", "/run"])
-    if not is_virtual and fstype != "unformatted":
-        try:
-            os.chmod(mount_point, 0o755)
-        except OSError as e:
-            libcalamares.utils.warning(f"Could not chmod {mount_point}: {e}")
 
     try:
         subprocess.call(['chcon', '--reference=' + raw_mount_point, mount_point])
@@ -277,10 +271,12 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     if fstype == "unformatted":
         return
 
-    if fstype == "fat16" or fstype == "fat32":
+    if fstype in ["fat16", "fat32", "exfat", "ntfs"]:
+        # Block non-FAT or any non-boot path
+        if fstype in ["exfat", "ntfs"] or raw_mount_point not in ["/boot", "/boot/efi"]:
+            libcalamares.utils.warning(f"Skipping {fstype} on {raw_mount_point}")
+            return
         fstype = "vfat"
-
-    device = partition["device"]
 
     if "luksMapperName" in partition:
         device = os.path.join("/dev/mapper", partition["luksMapperName"])
@@ -341,7 +337,8 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
             mount_options_list.append({"mountpoint": s["mountPoint"], "option_string": mount_options_string})
         else:
             libcalamares.utils.warning(f"Failed to mount subvolume {s['subvolume']}")
-            
+
+
 def enable_swap_partition(devices):
     try:
         for d in devices:

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -376,6 +376,7 @@ def run():
     else:
         extra_mounts = [m for m in extra_mounts if not m.get("efi")]
 
+    # mount_options_list will be inserted into global storage for use in fstab later
     mount_options_list = []
 
     # 4. Phase One: Physical (Depth Sort: / before /var)  

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -126,6 +126,7 @@ def get_mount_options(filesystem, mount_options, partition, efi_location = None)
     else:
         return "defaults"
 
+
 def get_btrfs_subvolumes(partitions):
     """
     Gets the job-configuration for btrfs subvolumes, or if there is

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -227,10 +227,11 @@ def mount_zfs(root_mount_point, partition):
             except subprocess.CalledProcessError:
                 raise ZfsException(_("Failed to set zfs mountpoint"))
     else:
-        try:
-            libcalamares.utils.host_env_process_output(["zfs", "mount", pool_name + '/' + ds_name])
-        except subprocess.CalledProcessError:
-            raise ZfsException(_("Failed to set zfs mountpoint"))
+        #try:
+            #libcalamares.utils.host_env_process_output(["zfs", "mount", pool_name + '/' + ds_name])
+        #except subprocess.CalledProcessError:
+            #raise ZfsException(_("Failed to set zfs mountpoint"))
+        err("ZFS is only supported on root (/).",am)
 
 def err(error_message, active_mounts):
     for tmp_dir in sorted(active_mounts, reverse=True):

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -357,7 +357,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
             # This tells Linux: "Put this specific subvolume here"
             sub_opts = f"subvol={s['subvolume']},{mount_options_string}"
         else:
-            err("subvolume not defined",am)
+            err("subvolume not defined",am) # not allowing this here
 
         # This builds the path INSIDE your new root
         sub_path = root_mount_point + s["mountPoint"]

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -387,6 +387,10 @@ def run():
             if mount.get("efi", None) is True:
                 extra_mounts.remove(mount)
 
+    # Add extra mounts to the partitions list and sort by mount points.
+    # This way, we ensure / is mounted before the rest, and every mount point
+    # is created on the right partition (e.g. if a partition is to be mounted
+    # under /tmp, we make sure /tmp is mounted before the partition)
     # mount_options_list will be inserted into global storage for use in fstab later
     mount_options_list = []
 

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -378,7 +378,9 @@ def run():
     if libcalamares.globalstorage.value("firmwareType") == "efi":
         efi_location = libcalamares.globalstorage.value("efiSystemPartition")
     else:
-        extra_mounts = [m for m in extra_mounts if not m.get("efi")]
+        for mount in extra_mounts:
+            if mount.get("efi", None) is True:
+                extra_mounts.remove(mount)
 
     # mount_options_list will be inserted into global storage for use in fstab later
     mount_options_list = []

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -296,8 +296,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     root_opts = f"subvol={root_sub['subvolume']},{mount_options_string}"
     if libcalamares.utils.mount(device, root_mount_point, fstype, root_opts) != 0:
         raise Exception(f"Failed to mount root subvolume {root_sub['subvolume']}")
-    # Add this after the root subvolume mount succeeds:
-    mount_options_list.append({"mountpoint": "/", "option_string": root_opts})  
+        
     # Step 3: Mount remaining subvolumes (like /home)
     for s in btrfs_subvolumes:
         if s["mountPoint"] == "/":

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -329,7 +329,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         if not s.get("mountPoint") or not s.get("subvolume"):
             err(f"Btrfs config error: entry missing mountPoint or subvolume name", am)
 
-    # Ensure root subolume with mountpoint / exists 
+    # Ensure root subvolume with mountpoint / exists 
     root_sub = next((s for s in btrfs_subvolumes if s["mountPoint"] == "/"), None)
     if not root_sub:
         err("Btrfs config error: root subvolume not found", am)

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -338,9 +338,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
 
     # Store created list in global storage so it can be used in the fstab module
     libcalamares.globalstorage.insert("btrfsSubvolumes", btrfs_subvolumes)
-    # Technical Debt: Calamares' fstab module expects a generic '/' entry
-    # in mount_options_list first. It then uses this 'btrfsRootSubvolume' key
-    # to find that generic entry and inject the 'subvol=@' string later.
+    # Fstab uses btrfsRootSubvolume to inject subvol=@ into generic / entry
     libcalamares.globalstorage.insert("btrfsRootSubvolume", root_sub['subvolume'])
 
     # Mount raw partition to create subvolumes

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -327,6 +327,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
 
     # Btrfs Setup
     btrfs_subvolumes = get_btrfs_subvolumes(partitions)
+
     # Ensure every entry has a subvolume name
     for s in btrfs_subvolumes:
         if not s.get("mountPoint") or not s.get("subvolume"):

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -244,7 +244,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     # SELinux-enabled systems.
 
     os.makedirs(mount_point, exist_ok=True)
-
+    fstype = partition.get("fs", "").lower()
     # Hardening: Only chmod physical paths. 
     # Skip virtuals (sys, proc, dev, run) and unformatted partitions.
     is_virtual = any(raw_mount_point.startswith(v) for v in ["/sys", "/proc", "/dev", "/run"])
@@ -262,7 +262,6 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         libcalamares.utils.error("Cannot run 'chcon' normally.")
         raise
 
-    fstype = partition.get("fs", "").lower()
     if fstype == "unformatted":
         return
 

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -357,9 +357,12 @@ def run():
                     "/dev/mapper/" + p["luksMapperName"] for p in claimed_swap]
     enable_swap_partition(swap_devices)
 
-    # 2. Setup Environment
     root_mount_point = tempfile.mkdtemp(prefix="calamares-root-")
+
+    # Get the mountOptions, if this is None, that is OK and will be handled later
     mount_options = libcalamares.job.configuration.get("mountOptions")
+
+    # Guard against missing keys (generally a sign that the config file is bad)
     extra_mounts = libcalamares.job.configuration.get("extraMounts") or []
     if not extra_mounts:
         libcalamares.utils.warning("No extra mounts defined. Does mount.conf exist?")

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -257,12 +257,12 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         return
 
     mount_options_string = get_mount_options(fstype, mount_options, partition, efi_location)
-
+    mount_options_list.append({"mountpoint": raw_mount_point, "option_string": mount_options_string})
     # Standard mount for everything EXCEPT Btrfs root
     if not (fstype == "btrfs" and raw_mount_point == '/'):
         if libcalamares.utils.mount(device, mount_point, fstype, mount_options_string) != 0:
             libcalamares.utils.warning(f"Cannot mount {device}")
-        mount_options_list.append({"mountpoint": raw_mount_point, "option_string": mount_options_string})
+
         return
 
     # Btrfs Root "Magic Trick" Logic

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -292,8 +292,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     if "luksMapperName" in partition:
         device = os.path.join("/dev/mapper", partition["luksMapperName"])
 
-    if fstype == "zfs":
-        # If mountpoint is not / pacstrap missing mkinitcpio hooks 
+    if fstype == "zfs": 
         mount_zfs(root_mount_point, partition)
         return
 

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -231,13 +231,6 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     os.makedirs(mount_point, exist_ok=True)
     fstype = partition.get("fs", "").lower()
 
-    #is_virtual = any(raw_mount_point.startswith(v) for v in ["/sys", "/proc", "/dev", "/run"])
-    #if not is_virtual and fstype != "unformatted":
-        #try:
-            #os.chmod(mount_point, 0o755)
-        #except OSError as e:
-            #libcalamares.utils.warning(f"Could not chmod {mount_point}: {e}")
-
     try:
         subprocess.call(['chcon', '--reference=' + raw_mount_point, mount_point])
     except:

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -279,7 +279,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
                     subprocess.check_call(["btrfs", "subvolume", "create", setup_dir + s["subvolume"]])
                     # Secure /root subvolume permissions
                     if s["mountPoint"] == "/root":
-                        os.chmod(sub_path, 0o750)
+                        os.chmod(setup_dir + s["subvolume"], 0o750)
         finally:
             # UNMOUNT 1: Close the "backdoor" so the temp directory can be cleaned up
             # We must clear this so we can remount using the '@' subvolume specifically.

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -298,7 +298,6 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
 
 
     mount_options_string = get_mount_options(fstype, mount_options, partition, efi_location)
-    mount_options_list.append({"mountpoint": raw_mount_point, "option_string": mount_options_string})
 
     # Standard mount for everything EXCEPT Btrfs root (this catches other btrfs partitions)
     if not (fstype == "btrfs" and raw_mount_point == '/'):
@@ -319,6 +318,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
                     f"Device {device} at {raw_mount_point} not empty. "
                     "Only /home or /srv allowed."), am)
 
+        mount_options_list.append({"mountpoint": raw_mount_point, "option_string": mount_options_string})
         return
 
 
@@ -380,11 +380,11 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
             mount_options_list.append({"mountpoint": s["mountPoint"], "option_string": mount_options_string})
         else:
             err(f"Failed to mount subvolume {s['subvolume']}", am)
-
-    # Store created list in global storage so it can be used in the fstab module
-    libcalamares.globalstorage.insert("btrfsSubvolumes", btrfs_subvolumes)
-    # Fstab uses btrfsRootSubvolume to inject subvol=/@ into generic / entry
+    
+    # Fstab module uses btrfsRootSubvolume to inject subvol=/@ into generic / entry
+    mount_options_list.append({"mountpoint": raw_mount_point, "option_string": mount_options_string})
     libcalamares.globalstorage.insert("btrfsRootSubvolume", root_sub['subvolume'])
+    libcalamares.globalstorage.insert("btrfsSubvolumes", btrfs_subvolumes)
 
 
 def enable_swap_partition(devices):

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -369,6 +369,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
             mount_options_list.append({"mountpoint": s["mountPoint"], "option_string": chosen_options})
         else:
             libcalamares.utils.warning(f"Failed to mount subvolume {s['subvolume']}")
+            raise Exception(f"Failed to mount subvolume {s['subvolume']}")
 
 
 def enable_swap_partition(devices):

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -307,7 +307,12 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
             err(f"Cannot mount {device}", am)
         # check only relevant partitions for ghost data
         if not is_virtual and raw_mount_point not in ["/home", "/srv", "/boot", "/boot/efi"]:
-            contents = [f for f in os.listdir(mount_point) if f not in ["lost+found", ".Trash-1000", "System Volume Information"]]
+            ignored_metadata = [
+                "lost+found", ".Trash-1000", "$RECYCLE.BIN", 
+                "System Volume Information", ".fseventsd", 
+                ".Spotlight-V100"
+                ]
+            contents = [f for f in os.listdir(mount_point) if f not in ignored_metadata]
             if contents:
                 err(f"Partition {device} has data. Please format.", am)
 

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -363,7 +363,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     if libcalamares.utils.mount(device, root_mount_point, fstype, root_opts) != 0:
         err(f"Failed to mount root subvolume {device}", am)
 
-    # Step 3: Mount remaining subvolumes (like /home)
+    # Mount remaining subvolumes
     for s in btrfs_subvolumes:
         if s["mountPoint"] == "/":
             libcalamares.globalstorage.insert("btrfsRootSubvolume", s["subvolume"])

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -313,7 +313,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
                 ]
             contents = [f for f in os.listdir(mount_point) if f not in ignored_metadata]
             if contents:
-                err(f"Device {device} at {raw_mount_point} has data. Please format or use /home or /srv.", am)
+                err(f"Device {device} at {raw_mount_point} has data. Please backup and format or use /home or /srv.", am)
 
         return
 
@@ -332,7 +332,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
                     err(f"Btrfs subvolume not defined {device}", am) # instead of continue
                 sub_path = setup_dir + s["subvolume"]
                 if os.path.exists(sub_path):
-                    err(f"Subvolume {s['subvolume']} already exists on {device}. Please format.", am)
+                    err(f"Subvolume {s['subvolume']} already exists on {device}. Please backup and format.", am)
             for s in btrfs_subvolumes:
                 sub_path = setup_dir + s["subvolume"]
                 os.makedirs(os.path.dirname(sub_path), exist_ok=True)

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -277,6 +277,9 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
                 if s["subvolume"]:
                     os.makedirs(setup_dir + os.path.dirname(s["subvolume"]), exist_ok=True)
                     subprocess.check_call(["btrfs", "subvolume", "create", setup_dir + s["subvolume"]])
+                    # Secure /root subvolume permissions
+                    if s["mountPoint"] == "/root":
+                        os.chmod(sub_path, 0o750)
         finally:
             # UNMOUNT 1: Close the "backdoor" so the temp directory can be cleaned up
             # We must clear this so we can remount using the '@' subvolume specifically.

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -313,7 +313,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
                 ]
             contents = [f for f in os.listdir(mount_point) if f not in ignored_metadata]
             if contents:
-                err(f"Device {device} at {raw_mount_point} has data. Please backup and format or use /home or /srv.", am)
+                err(f"Device {device} at {raw_mount_point} has data. Please backup and format or use /home or /srv for this partition.", am)
 
         return
 
@@ -332,7 +332,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
                     err(f"Btrfs subvolume not defined {device}", am) # instead of continue
                 sub_path = setup_dir + s["subvolume"]
                 if os.path.exists(sub_path):
-                    err(f"Subvolume {s['subvolume']} already exists on {device}. Please backup and format.", am)
+                    err(f"Subvolume {s['subvolume']} already exists on {device}. Please backup and format or use /home or /srv for this partition.", am)
             for s in btrfs_subvolumes:
                 sub_path = setup_dir + s["subvolume"]
                 os.makedirs(os.path.dirname(sub_path), exist_ok=True)

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -338,7 +338,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
 
     # Store created list in global storage so it can be used in the fstab module
     libcalamares.globalstorage.insert("btrfsSubvolumes", btrfs_subvolumes)
-    # TECHNICAL DEBT ALERT: Calamares' fstab module expects a generic '/' entry
+    # Technical Debt: Calamares' fstab module expects a generic '/' entry
     # in mount_options_list first. It then uses this 'btrfsRootSubvolume' key
     # to find that generic entry and inject the 'subvol=@' string later.
     libcalamares.globalstorage.insert("btrfsRootSubvolume", root_sub['subvolume'])

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -361,13 +361,12 @@ def run():
 
     # Get the mountOptions, if this is None, that is OK and will be handled later
     mount_options = libcalamares.job.configuration.get("mountOptions")
-
+    mount_options_list = []
+    
     # Guard against missing keys (generally a sign that the config file is bad)
     extra_mounts = libcalamares.job.configuration.get("extraMounts") or []
     if not extra_mounts:
         libcalamares.utils.warning("No extra mounts defined. Does mount.conf exist?")
-
-    mount_options_list = []
 
     efi_location = None
     if libcalamares.globalstorage.value("firmwareType") == "efi":

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -312,7 +312,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         try: # <--- You need this line!
             for s in btrfs_subvolumes:
                 if not s["subvolume"]:
-                    continue # better not crash here
+                    continue # not throwing exception
                 sub_path = setup_dir + s["subvolume"]
                 if not os.path.exists(sub_path):
                     os.makedirs(os.path.dirname(sub_path), exist_ok=True)

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -279,7 +279,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
             # Manually release the SSD so Python can delete setup_dir
             subprocess.check_call(["umount", "-v", setup_dir])
     # Step 2: Swap raw mount for @ subvolume mount
-    subprocess.check_call(["umount", "-v", root_mount_point])
+    subprocess.check_call(["umount", "-l", "-v", root_mount_point])
     
     root_sub = next((s for s in btrfs_subvolumes if s["mountPoint"] == "/"), None)
     if not root_sub:

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -257,6 +257,14 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     # SELinux-enabled systems.
 
     os.makedirs(mount_point, exist_ok=True)
+    fstype = partition.get("fs", "").lower()
+
+    is_virtual = any(raw_mount_point.startswith(v) for v in ["/sys", "/proc", "/dev", "/run"])
+    if not is_virtual and fstype != "unformatted":
+        try:
+            os.chmod(mount_point, 0o755)
+        except OSError as e:
+            libcalamares.utils.warning(f"Could not chmod {mount_point}: {e}")
 
     try:
         subprocess.call(['chcon', '--reference=' + raw_mount_point, mount_point])
@@ -266,7 +274,6 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         libcalamares.utils.error("Cannot run 'chcon' normally.")
         raise
 
-    fstype = partition.get("fs", "").lower()
     if fstype == "unformatted":
         return
 

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -282,7 +282,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     am.append(mount_point)
     device = partition["device"]
 
-    # Only allow fat32 on boot path, block incompatible
+    # Only allow fat32 on boot path and block incompatible
     if fstype in ["fat16", "fat32", "ntfs", "ext2", "exfat"]:
         is_boot = raw_mount_point in ["/boot", "/boot/efi"]
         if not (is_boot and fstype == "fat32"):
@@ -294,7 +294,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
 
     if fstype == "zfs":
         if raw_mount_point != '/':
-            # pacstrap failure mkinitcpio hook missing
+            # Pacstrap failure mkinitcpio hook missing
             err("Manual ZFS unsupported. Use 'Erase Disk'.", am)
         mount_zfs(root_mount_point, partition)
         return
@@ -338,7 +338,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
 
     # Store created list in global storage so it can be used in the fstab module
     libcalamares.globalstorage.insert("btrfsSubvolumes", btrfs_subvolumes)
-    # insert the root subvolume into global storage
+    # Insert the root subvolume into global storage
     libcalamares.globalstorage.insert("btrfsRootSubvolume", root_sub['subvolume'])
 
     # Mount raw partition to create subvolumes
@@ -441,7 +441,8 @@ def run():
     # mount_options_list will be inserted into global storage for use in fstab later
     mount_options_list = []
     active_mounts = []
-    # 4. Phase One: Physical (Lexical Depth Sort: / before /var)  
+
+    # Lexical Depth Sort: mount before sub-paths  
     physical = [p for p in partitions if "mountPoint" in p and p["mountPoint"]]
     physical.sort(key=lambda x: x["mountPoint"])
 
@@ -449,7 +450,7 @@ def run():
         for p in physical:
             mount_partition(root_mount_point, p, partitions, mount_options, mount_options_list, efi_location, active_mounts)
          
-        # 5. Phase Two: Bind/Virtual (After Btrfs subvolumes exist)
+        # Bind/Virtual: After creating Btrfs subvolumes
         extra = [p for p in extra_mounts if "mountPoint" in p and p["mountPoint"]]
         extra.sort(key=lambda x: x["mountPoint"])
 

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -277,7 +277,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         if not is_boot or fstype in ["ntfs", "ext2"] or (fstype == "exfat" and efi_location):
             libcalamares.utils.warning(f"Unsupported partition with {fstype} on {raw_mount_point}")
             raise Exception(f"Unsupported partition with {fstype} on {raw_mount_point}")
-            return
+            # return (fstab still sees the partition)
         fstype = "vfat" if fstype != "exfat" else "exfat"
 
     if "luksMapperName" in partition:

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -290,10 +290,6 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     root_opts = f"subvol={root_sub['subvolume']},{mount_options_string}"
     if libcalamares.utils.mount(device, root_mount_point, fstype, root_opts) != 0:
         raise Exception(f"Failed to mount root subvolume")
-
-    root_opts = f"subvol={root_sub['subvolume']},{mount_options_string}"
-    if libcalamares.utils.mount(device, root_mount_point, fstype, root_opts) != 0:
-        raise Exception(f"Failed to mount root subvolume {root_sub['subvolume']}")
         
     # Step 3: Mount remaining subvolumes (like /home)
     for s in btrfs_subvolumes:

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -290,9 +290,11 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     for s in btrfs_subvolumes:
         if s["mountPoint"] == "/":
             continue
-        
+            
+        # This builds the path INSIDE your new root
         sub_path = root_mount_point + s["mountPoint"]
         os.makedirs(sub_path, exist_ok=True)
+        # This tells Linux: "Put this specific subvolume here"
         sub_opts = f"subvol={s['subvolume']},{mount_options_string}"
         
         if libcalamares.utils.mount(device, sub_path, fstype, sub_opts) != 0:

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -322,7 +322,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
                 if not s["subvolume"]:
                     err(f"Btrfs subvolume not defined {device}",am) # instead of continue
                 sub_path = setup_dir + s["subvolume"]
-                if not os.path.exists(sub_path):
+                if not os.path.exists(sub_path): # if this exists user is at fault
                     os.makedirs(os.path.dirname(sub_path), exist_ok=True)
                     subprocess.check_call(["btrfs", "subvolume", "create", sub_path])
                     if s["mountPoint"] == "/root":

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -281,7 +281,6 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
         # Block if: not a boot path, OR ntfs/ext2, OR exfat on UEFI
         if not is_boot or fstype in ["ntfs", "ext2"] or (fstype == "exfat" and efi_location):
             err(f"Unsupported partition with {fstype} on {raw_mount_point}",am)
-            # return (fstab still sees the partition)
         fstype = "vfat" if fstype != "exfat" else "exfat"
 
     if "luksMapperName" in partition:

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -223,6 +223,17 @@ def mount_zfs(root_mount_point, partition):
 
 
 def mount_partition(root_mount_point, partition, partitions, mount_options, mount_options_list, efi_location):
+    """
+    Do a single mount of @p partition inside @p root_mount_point.
+
+    :param root_mount_point: A string containing the root of the install
+    :param partition: A dict containing information about the partition
+    :param partitions: The full list of partitions used to filter out btrfs subvols which have duplicate mountpoints
+    :param mount_options: The mount options from the config file
+    :param mount_options_list: A list of options for each mountpoint to be placed in global storage for future modules
+    :param efi_location: A string holding the location of the EFI partition or None
+    :return:
+    """
     raw_mount_point = partition["mountPoint"]
     if not raw_mount_point:
         return

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -313,7 +313,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
                 ]
             contents = [f for f in os.listdir(mount_point) if f not in ignored_metadata]
             if contents:
-                err(f"Partition {device} has data. Please format or use /home or /srv.", am)
+                err(f"Device {device} at {raw_mount_point} has data. Please format or use /home or /srv.", am)
 
         return
 

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -322,8 +322,14 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     if not root_sub:
         libcalamares.utils.warning(f"Btrfs root subvolume (/) not found")
         raise Exception("Btrfs root subvolume (/) not found!")
+
     # Mount the specific @ subvolume to the root mount point
-    root_opts = f"subvol={root_sub['subvolume']},{mount_options_string}"
+    # Handle empty subvolume name for the root mount
+    if root_sub['subvolume']:
+        root_opts = f"subvol={root_sub['subvolume']},{mount_options_string}"
+    else:
+        root_opts = mount_options_string
+
     if libcalamares.utils.mount(device, root_mount_point, fstype, root_opts) != 0:
         libcalamares.utils.warning(f"Failed to mount root subvolume {device}")
         raise Exception(f"Failed to mount root subvolume {device}")

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -277,6 +277,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     if fstype == "unformatted":
         return
 
+
     am = active_mounts
     am.append(mount_point)
     device = partition["device"]
@@ -318,6 +319,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
                 err(f"Device {device} at {raw_mount_point} not empty. Please backup and format or use /home or /srv for this partition.", am)
 
         return
+
 
     # Btrfs Setup
     btrfs_subvolumes = get_btrfs_subvolumes(partitions)

--- a/src/modules/mount/main.py
+++ b/src/modules/mount/main.py
@@ -333,7 +333,7 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
     if root_sub['subvolume']:
         root_opts = f"subvol={root_sub['subvolume']},{mount_options_string}"
     else:
-        root_opts = mount_options_string
+        raise Exception(f"Configuration error: root subvolume not defined")
 
     if libcalamares.utils.mount(device, root_mount_point, fstype, root_opts) != 0:
         libcalamares.utils.warning(f"Failed to mount root subvolume {device}")


### PR DESCRIPTION
Pull Request: Refactor Btrfs sandboxing and implement lexical error unwinding (mount/main.py)

This PR structurally refactors the mount module to eliminate critical race conditions and dirty live-environment states during complex or esoteric partition installations. By isolating Btrfs subvolume creation inside an ephemeral context manager and implementing a reverse-lexical unmount stack, it guarantees the live environment remains completely sterile even if an installation crashes mid-flight. Furthermore, it explicitly separates physical block initialization from virtual kernel binds and aggressively catches invalid edge-case mounts (e.g., attempting to map fat32 to /var or deploying to non-empty directories). Ultimately, this makes the Calamares deployment pipeline significantly more robust, crash-resilient, and safe for users building highly customized storage layouts.

CAVEAT: I left out btrfs swap to file functionality because cachyos explicitly disables it and uses zram instead. 

### **Architectural Overhauls**

**1. Strict Error Handling & Mount Tracking**

* **The Problem:** The vanilla script merely logged warnings when critical mounts (or Btrfs operations) failed, allowing the installation to proceed with missing or misaligned partitions.
* **The Fix:** Introduced a centralized `err(error_message, active_mounts)` function.
* **Mechanics:** Mount points are now appended to an `active_mounts` list as they are processed. If *any* check fails, `err()` catches the exception, iterates through `active_mounts` in reverse order, and guarantees a clean unmount (falling back to a lazy unmount `-l` if the standard unmount fails) before halting the process with a hard `Exception`.

**2. Btrfs Subvolume Refactoring & Isolation**

* **The Problem:** The vanilla script mounted the root Btrfs filesystem directly to the final `root_mount_point`, created subvolumes, unmounted it, and remounted it. It also failed to account for nested partitions overriding subvolumes.
* **The Fix:**
* **Nested Mount Filtering:** Subvolume creation is now intelligently skipped if a dedicated partition is mounted *inside* that path (e.g., preventing a subvolume for `/var/log` if a separate physical partition is explicitly mapped to `/var/log`).
* **Pre-Flight Checks:** Enforces that all Btrfs configurations have both a `mountPoint` and `subvolume` name defined, and mandates the existence of a root (`/`) subvolume.
* **Safe Sandbox Creation:** Btrfs partitions are now mounted to a temporary, isolated directory (`calam-btrfs-XXXXXX`) strictly for subvolume creation. It verifies that target subvolumes do not already exist (preventing destructive overwrites) before safely unmounting the sandbox and mounting the designated root subvolume (`subvol=/@`) to the actual `root_mount_point`.



**3. Two-Pass Mount Ordering (Physical vs. Virtual)**

* **The Problem:** Vanilla combined physical partitions and virtual/bind mounts (`extraMounts`) into a single list and sorted them lexically. This could result in virtual mounts attempting to bind to paths before the underlying physical subvolumes or partitions were fully initialized.
* **The Fix:** Mount logic is now explicitly separated into two passes:
1. **Physical Partitions:** Sorted lexically and mounted first (including the generation of Btrfs subvolumes).
2. **Extra/Virtual Mounts:** Sorted lexically and mounted *after* the physical hierarchy is strictly established.



---

### **Validation & Safety Enhancements**

**Filesystem Compatibility Enforcement**

* Added rigorous checks for boot partition filesystems. If `/boot` or `/boot/efi` is targeted, it explicitly blocks `fat16`, `ntfs`, `ext2`, and `exfat`, forcing `fat32` (mapped as `vfat`).
* Any attempt to mount an incompatible filesystem to a boot path triggers the `err()` rollback.

**Target Directory "Dirty" Checks**

* Before mounting a non-virtual partition, the script now scans the target mount point for pre-existing data.
* It explicitly ignores standard OS metadata directories (`lost+found`, `.Trash-1000`, `$RECYCLE.BIN`, `System Volume Information`, etc.).
* If unexpected files are found (and the target is not explicitly `/home` or `/srv`), the installation halts. This crucially prevents the installer from blindly mounting over and obscuring existing user data.

---

### **Code Quality & Bug Fixes**

* **List Iteration Bug Fix:** In the vanilla script, `extra_mounts.remove(mount)` was called while actively iterating over `extra_mounts`. Modifying a list during iteration in Python causes elements to be skipped. This was patched cleanly using a list comprehension: `extra_mounts = [m for m in extra_mounts if not m.get("efi")]`.
* **Simplification of Btrfs Mount Options:** Stripped out redundant fallback logic when appending `subvol=` strings to mount options, streamlining the fstab string injection.
* **ZFS Delegation:** Simplified the ZFS conditional check. If a partition is ZFS, it routes to `mount_zfs()` and immediately `return`s, preventing it from bleeding into the standard mount logic.