### PR TITLE
services-systemd: Add support for user services and enable cachy-update

### DIFF
--- a/src/modules/services-systemd/main.py
+++ b/src/modules/services-systemd/main.py
@@ -49,9 +49,14 @@ def systemctl(units):
             action = unit.get("action", "enable")
             mandatory = unit.get("mandatory", False)
 
-        exit_code = libcalamares.utils.target_env_call(
-            ['systemctl', action, name]
-        )
+        user_service = unit.get("user", False) if isinstance(unit, dict) else False
+
+        if user_service:
+            cmd = ['systemctl', '--global', action, name]
+        else:
+            cmd = ['systemctl', action, name]
+
+        exit_code = libcalamares.utils.target_env_call(cmd)
 
         if exit_code != 0:
             libcalamares.utils.warning(

--- a/src/modules/services-systemd/main.py
+++ b/src/modules/services-systemd/main.py
@@ -41,15 +41,15 @@ def systemctl(units):
             name = unit
             action = "enable"
             mandatory = False
+            user_service = False
         else:
             if "name" not in unit:
                 libcalamares.utils.error("The key 'name' is missing from the mapping {_unit!s}. Continuing to the next unit.".format(_unit=str(unit)))
-                continue 
+                continue
             name = unit["name"]
             action = unit.get("action", "enable")
             mandatory = unit.get("mandatory", False)
-
-        user_service = unit.get("user", False) if isinstance(unit, dict) else False
+            user_service = unit.get("user", False)
 
         if user_service:
             cmd = ['systemctl', '--global', action, name]

--- a/src/modules/services-systemd/services-systemd.conf
+++ b/src/modules/services-systemd/services-systemd.conf
@@ -72,3 +72,13 @@ units:
    - name: "bluetooth"
      action: "enable"
      mandatory: false
+
+   - name: "arch-update.timer"
+     action: "enable"
+     mandatory: false
+     user: true
+
+   - name: "arch-update-tray.service"
+     action: "enable"
+     mandatory: false
+     user: true

--- a/src/modules/services-systemd/services-systemd.schema.yaml
+++ b/src/modules/services-systemd/services-systemd.schema.yaml
@@ -13,6 +13,7 @@ definitions:
             name: { type: string }
             action: { type: string, default: "enable" }
             mandatory: { type: boolean, default: false }
+            user: { type: boolean, default: false }
         required: [ name ]
 
 additionalProperties: false


### PR DESCRIPTION
Add a 'user' flag to the services-systemd module that uses 'systemctl --global' to enable systemd user units during installation. This allows enabling user services from a chroot context, where 'systemctl --user' is not available.

Enable arch-update.timer and arch-update-tray.service as user units for automatic update checks and systray notifications.