### PR TITLE
netinstall: Add ufw-extra package

### DIFF
--- a/src/modules/netinstall/netinstall.yaml
+++ b/src/modules/netinstall/netinstall.yaml
@@ -61,6 +61,7 @@
         selected: true
         packages:
           - ufw
+          - ufw-extra
       - name: "bluetooth"
         description: "Bluetooth support"
         selected: true


### PR DESCRIPTION
The package contains rules for: KDE Connect, Cups, megasync, samba, etc. so it makes sense to install it by default.