### PR TITLE
pacstrap: Remove old microcode if reusing boot partition

### DIFF
--- a/src/modules/pacstrap/main.py
+++ b/src/modules/pacstrap/main.py
@@ -144,6 +144,17 @@ def run():
         base_packages += ["bcachefs-tools", "bcachefs-dkms"]
 
 
+    # Clean up stale ucode files from reused ESP to avoid pacman "exists in filesystem" conflicts
+    boot_path = os.path.join(root_mount_point, "boot")
+    for ucode_img in ["intel-ucode.img", "amd-ucode.img"]:
+        ucode_path = os.path.join(boot_path, ucode_img)
+        if os.path.exists(ucode_path):
+            try:
+                os.remove(ucode_path)
+                libcalamares.utils.debug("Removed stale ucode file: {!s}".format(ucode_path))
+            except Exception as e:
+                libcalamares.utils.warning("Failed to remove stale ucode file {!s}: {!s}".format(ucode_path, e))
+
     # run the pacstrap
     pacstrap_command = ["/etc/calamares/scripts/pacstrap_calamares", "-c", root_mount_point] + base_packages
 


### PR DESCRIPTION
Many people reporting since the recent change, when reusing the efi/boot partition that the installation fails with:

```
2026-03-12 - 17:44:25 [6]: [PYTHON JOB]: "pacstrap: intel-ucode: /tmp/calamares-root-dglv7qon/boot/intel-ucode.img exists in filesystem"
```

