### PR TITLE
partition: Print into debug log the used partition method

### DIFF
--- a/src/modules/partition/PartitionViewStep.cpp
+++ b/src/modules/partition/PartitionViewStep.cpp
@@ -387,7 +387,7 @@ PartitionViewStep::next()
                 m_manualPartitionPage->onRevertClicked();
             }
         }
-        cDebug() << "Choice applied: " << m_config->installChoice();
+        cDebug() << "Partition method selected:" << Config::installChoiceNames().find( m_config->installChoice() );
     }
 }
 

--- a/src/modules/partition/jobs/FillGlobalStorageJob.cpp
+++ b/src/modules/partition/jobs/FillGlobalStorageJob.cpp
@@ -341,6 +341,10 @@ FillGlobalStorageJob::exec()
 {
     Calamares::GlobalStorage* storage = Calamares::JobQueue::instance()->globalStorage();
     const auto partitions = createPartitionList();
+    const auto partitionChoices = storage->value( "partitionChoices" ).toMap();
+    const auto installChoice = partitionChoices.value( "install" ).toString();
+    cDebug() << Logger::SubEntry << "Partition method:" << installChoice;
+
     cDebug() << "Saving partition information map to GlobalStorage[\"partitions\"]";
     storage->insert( "partitions", partitions );
     storeFSUse( storage, partitions );


### PR DESCRIPTION
When debugging user reported logs we have often problems finding out, which kind of partitioning they used.

Printing the partition method into the Debug log directly would improve this and we can just search for the terms "erase", "replace", "alongside", or "manual"