### PR TITLE
netinstall: Add linux-firmware-marvell to hardware packages

### DIFF
--- a/src/modules/netinstall/netinstall.yaml
+++ b/src/modules/netinstall/netinstall.yaml
@@ -144,6 +144,7 @@
           - hdparm
           - hwdetect
           - linux-firmware
+          - linux-firmware-marvell
           - lsscsi
           - mesa-utils
           - mtools


### PR DESCRIPTION
linux-firmware-marvell is included on the live ISO but missing from the netinstall hardware group. This causes Marvell AVASTAR Wi-Fi/Bluetooth devices (e.g. Surface Pro 4 with 88W8897) to lose connectivity after installation.

Fixes CachyOS/CachyOS-Live-ISO#89