### PR TITLE
plymouthcfg: Add support for AMD GPU-specific Plymouth theme

### DIFF
--- a/src/modules/plymouthcfg/main.py
+++ b/src/modules/plymouthcfg/main.py
@@ -12,6 +12,8 @@
 #   Calamares is Free Software: see the License-Identifier above.
 #
 
+import os
+
 import libcalamares
 
 from libcalamares.utils import debug, target_env_call
@@ -21,6 +23,11 @@ _ = gettext.translation("calamares-python",
                         localedir=libcalamares.utils.gettext_path(),
                         languages=libcalamares.utils.gettext_languages(),
                         fallback=True).gettext
+
+# AMD PCI vendor ID
+AMD_VENDOR_ID = "0x1002"
+# PCI display device classes (VGA controller and 3D controller)
+DISPLAY_CLASSES = ("0x030000", "0x030200", "0x038000")
 
 
 def pretty_name():
@@ -37,6 +44,33 @@ def detect_plymouth():
     return target_env_call(["sh", "-c", "which plymouth"]) == 0
 
 
+def detect_amdgpu():
+    """
+    Checks if an AMD GPU is present by reading PCI device info from sysfs.
+
+    @return True if an AMD GPU is detected, False otherwise
+    """
+    pci_devices = "/sys/bus/pci/devices"
+    try:
+        for device in os.listdir(pci_devices):
+            device_path = os.path.join(pci_devices, device)
+            vendor_path = os.path.join(device_path, "vendor")
+            class_path = os.path.join(device_path, "class")
+            try:
+                with open(vendor_path, "r") as f:
+                    vendor = f.read().strip()
+                with open(class_path, "r") as f:
+                    dev_class = f.read().strip()
+            except OSError:
+                continue
+            if vendor == AMD_VENDOR_ID and dev_class in DISPLAY_CLASSES:
+                debug("Detected AMD GPU: {}".format(device))
+                return True
+    except OSError:
+        debug("Could not read PCI devices from sysfs")
+    return False
+
+
 class PlymouthController:
 
     def __init__(self):
@@ -47,8 +81,14 @@ class PlymouthController:
         return self.__root
 
     def setTheme(self):
-        plymouth_theme = libcalamares.job.configuration["plymouth_theme"]
-        target_env_call(["plymouth-set-default-theme",  plymouth_theme])
+        config = libcalamares.job.configuration
+        plymouth_theme = config["plymouth_theme"]
+
+        if config.get("plymouth_theme_amdgpu") and detect_amdgpu():
+            plymouth_theme = config["plymouth_theme_amdgpu"]
+            debug("Using AMD GPU plymouth theme: {}".format(plymouth_theme))
+
+        target_env_call(["plymouth-set-default-theme", plymouth_theme])
 
     def run(self):
         if detect_plymouth():

--- a/src/modules/plymouthcfg/main.py
+++ b/src/modules/plymouthcfg/main.py
@@ -12,7 +12,7 @@
 #   Calamares is Free Software: see the License-Identifier above.
 #
 
-import os
+import subprocess
 
 import libcalamares
 
@@ -23,11 +23,6 @@ _ = gettext.translation("calamares-python",
                         localedir=libcalamares.utils.gettext_path(),
                         languages=libcalamares.utils.gettext_languages(),
                         fallback=True).gettext
-
-# AMD PCI vendor ID
-AMD_VENDOR_ID = "0x1002"
-# PCI display device classes (VGA controller and 3D controller)
-DISPLAY_CLASSES = ("0x030000", "0x030200", "0x038000")
 
 
 def pretty_name():
@@ -46,28 +41,20 @@ def detect_plymouth():
 
 def detect_amdgpu():
     """
-    Checks if an AMD GPU is present by reading PCI device info from sysfs.
+    Checks if an AMD GPU is present using chwd.
 
     @return True if an AMD GPU is detected, False otherwise
     """
-    pci_devices = "/sys/bus/pci/devices"
     try:
-        for device in os.listdir(pci_devices):
-            device_path = os.path.join(pci_devices, device)
-            vendor_path = os.path.join(device_path, "vendor")
-            class_path = os.path.join(device_path, "class")
-            try:
-                with open(vendor_path, "r") as f:
-                    vendor = f.read().strip()
-                with open(class_path, "r") as f:
-                    dev_class = f.read().strip()
-            except OSError:
-                continue
-            if vendor == AMD_VENDOR_ID and dev_class in DISPLAY_CLASSES:
-                debug("Detected AMD GPU: {}".format(device))
-                return True
+        result = subprocess.run(
+            ["chwd", "--check", "amd"],
+            capture_output=True, text=True
+        )
+        if result.returncode == 0:
+            debug("Detected AMD GPU via chwd")
+            return True
     except OSError:
-        debug("Could not read PCI devices from sysfs")
+        debug("Could not run chwd for AMD GPU detection")
     return False
 
 

--- a/src/modules/plymouthcfg/plymouthcfg.conf
+++ b/src/modules/plymouthcfg/plymouthcfg.conf
@@ -26,6 +26,8 @@
 
 plymouth_theme: cachyos-bootanimation
 
-
-
+# Optional: set a different theme for systems with AMD GPUs.
+# If an AMD GPU is detected and this is set, it overrides plymouth_theme.
+# Leave commented to use the same theme for all hardware.
+plymouth_theme_amdgpu: cachyos
 

--- a/src/modules/plymouthcfg/plymouthcfg.schema.yaml
+++ b/src/modules/plymouthcfg/plymouthcfg.schema.yaml
@@ -7,3 +7,4 @@ additionalProperties: false
 type: object
 properties:
     plymouth_theme: { type: string }
+    plymouth_theme_amdgpu: { type: string }


### PR DESCRIPTION
Some Plymouth themes are broken on specific AMD GPUs. Add a plymouth_theme_amdgpu config variable that, when set, overrides the default theme on systems with an AMD GPU. Detection is done via sysfs PCI device enumeration (vendor 0x1002 + display device class)