### PR TITLE
netinstall: Replace octopi with shelly

### DIFF
--- a/src/modules/netinstall/netinstall.yaml
+++ b/src/modules/netinstall/netinstall.yaml
@@ -80,7 +80,7 @@
           - rebuild-detector
           - reflector
           - paru
-          - octopi
+          - shelly
       - name: "desktop integration"
         description: "Useful helper tools and libs for desktop usage"
         selected: true


### PR DESCRIPTION
Shelly has developed very well and is likely miles ahead of octopi. Octopi also has problems on CachyOS like listing packages twice.

Shelly developers are very active in the CachyOS community and bringing new features and fixes very fast.

Change the default to shelly.