### PR TITLE
partition: Fix reuse home partition not preserving data

### DIFF
--- a/src/modules/partition/gui/ChoicePage.cpp
+++ b/src/modules/partition/gui/ChoicePage.cpp
@@ -912,6 +912,7 @@ ChoicePage::doReplaceSelectedPartition( const QModelIndex& current )
                         if ( homePartition && doReuseHomePartition )
                         {
                             PartitionInfo::setMountPoint( homePartition, "/home" );
+                            PartitionInfo::setFormat( homePartition, false );
                             gs->insert( "reuseHome", true );
                         }
                         else

--- a/src/modules/users/CreateUserJob.cpp
+++ b/src/modules/users/CreateUserJob.cpp
@@ -132,9 +132,11 @@ CreateUserJob::exec()
             QString backupDirName = "dotfiles_backup_" + QDateTime::currentDateTime().toString( "yyyy-MM-dd_HH-mm-ss" );
             existingHome.mkdir( backupDirName );
 
-            // We need the extra `sh -c` here to ensure that we can expand the shell globs
+            // Use find to avoid the shell glob issue where .* matches . and ..
             Calamares::System::instance()->targetEnvCall(
-                { "sh", "-c", "mv -f " + shellFriendlyHome + "/.* " + shellFriendlyHome + "/" + backupDirName } );
+                { "find", shellFriendlyHome, "-maxdepth", "1", "-name", ".*",
+                  "!", "-name", ".", "!", "-name", "..",
+                  "-exec", "mv", "-f", "{}", shellFriendlyHome + "/" + backupDirName + "/", "+" } );
         }
     }
 


### PR DESCRIPTION
The Replace partition flow was missing setFormat(false) on the home partition, causing it to be formatted despite the user choosing to reuse it.

Also fix the dotfile backup command in CreateUserJob which used a shell glob (.*) that matches . and .., replacing it with find to correctly select only actual dotfiles.