### PR TITLE
Cleanup and modernise GNOME packages in netinstall

### DIFF
--- a/src/modules/netinstall/netinstall.yaml
+++ b/src/modules/netinstall/netinstall.yaml
@@ -238,9 +238,9 @@
     - cachy-update
     - fwupd
     - gdm
-    - gedit
+    - gnome-text-editor
     - gnome-backgrounds
-    - gnome-console
+    - ptyxis
     - gnome-control-center
     - gnome-keyring
     - gnome-shell
@@ -259,10 +259,12 @@
           - gnome-disk-utility
           - gnome-power-manager
           - gnome-calculator
-          - gnome-nettool
-          - gnome-usage
+          - gnome-system-monitor
+          - baobab
           - malcontent
           - showtime
+          - decibels
+          - snapshot
           - gvfs-afc
           - gvfs-nfs
           - gvfs-smb


### PR DESCRIPTION
Following a recent CachyOS+GNOME install, I noticed some weird defaults. This PR seeks to update some deprecated packages, and add a couple of essentials. I have tested all of the packages in a VM and checked their functionality - particularly Ptyxis (the only potential problem), verifying CachyOS Hello and Cachy Updater don't break spawning terminals. Everything seems to be in order, and Alacritty exists as a fallback anyway.

- Replaced `gnome-console` with the newer `ptyxis`.
- Replaced `gedit` with the newer replacement `gnome-text-editor`.
- Removed the entirely deprecated `gnome-nettool`.
- Replaced the near-abandoned and incomplete `gnome-usage` with `gnome-system-monitor`. Not sure why this was ever added.
- Added `baobab`, `decibels` and `snapshot`, the disk usage analyser, audio player and camera app for GNOME.

I noticed the existence of a `cachyos-gnome-settings` pkgbuild, but appears to have been removed from the netinstall. Not sure what the rationale was behind that, whether the `cachyos-x-settings` architecture is being moved away from or it's just for maintainability reasons.