### PR TITLE
shellprocess: create permanent btrfs installation snapshot after install

### DIFF
--- a/settings.conf
+++ b/settings.conf
@@ -38,6 +38,10 @@ instances:
   module:   shellprocess
   config:   shellprocess_limine.conf
 
+- id:       btrfs_snapshot
+  module:   shellprocess
+  config:   shellprocess_btrfs_snapshot.conf
+
 
 sequence:
 - show:
@@ -80,6 +84,7 @@ sequence:
   - services-systemd
   - shellprocess
   - shellprocess@enable_ufw
+  - shellprocess@btrfs_snapshot
   - umount
 - show:
   - finished

--- a/settings_online.conf
+++ b/settings_online.conf
@@ -43,6 +43,10 @@ instances:
   module:   shellprocess
   config:   shellprocess_enable_ufw.conf
 
+- id:       btrfs_snapshot
+  module:   shellprocess
+  config:   shellprocess_btrfs_snapshot.conf
+
 
 sequence:
 - show:
@@ -86,6 +90,7 @@ sequence:
   - services-systemd
   - shellprocess
   - shellprocess@enable_ufw
+  - shellprocess@btrfs_snapshot
   - umount
 - show:
   - finished

--- a/src/modules/pacstrap/pacstrap.conf
+++ b/src/modules/pacstrap/pacstrap.conf
@@ -73,3 +73,4 @@ postInstallFiles:
   - "/etc/calamares/scripts/enable-ufw"
   - "/etc/calamares/scripts/bootloader-post-setup"
   - "/etc/calamares/scripts/shell-setup"
+  - "/etc/calamares/scripts/btrfs-installation-snapshot"

--- a/src/modules/shellprocess/shellprocess_btrfs_snapshot.conf
+++ b/src/modules/shellprocess/shellprocess_btrfs_snapshot.conf
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: CC0-1.0
 #
 # Creates a permanent btrfs snapshot of the fresh installation via snapper.
-# The snapshot uses an empty cleanup-algorithm so snapper's cleanup timers
-# will never remove it — it is intended as a "reset to fresh install" restore point.
-# Silently skips if the root filesystem is not btrfs or snapper is not configured.
+# Snapper defaults to no cleanup algorithm, so the snapshot will never be
+# automatically removed — it is intended as a "reset to fresh install" restore point.
+# Silently skips if cachyos-snapper-support is not installed.
 ---
 
 dontChroot: false

--- a/src/modules/shellprocess/shellprocess_btrfs_snapshot.conf
+++ b/src/modules/shellprocess/shellprocess_btrfs_snapshot.conf
@@ -8,7 +8,7 @@
 ---
 
 dontChroot: false
-timeout: 30
+timeout: 300
 script:
     - command: "/etc/calamares/scripts/btrfs-installation-snapshot"
     - "-rm /etc/calamares/scripts/btrfs-installation-snapshot"

--- a/src/modules/shellprocess/shellprocess_btrfs_snapshot.conf
+++ b/src/modules/shellprocess/shellprocess_btrfs_snapshot.conf
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: no
+# SPDX-License-Identifier: CC0-1.0
+#
+# Creates a permanent btrfs snapshot of the fresh installation via snapper.
+# The snapshot uses an empty cleanup-algorithm so snapper's cleanup timers
+# will never remove it — it is intended as a "reset to fresh install" restore point.
+# Silently skips if the root filesystem is not btrfs or snapper is not configured.
+---
+
+dontChroot: false
+timeout: 30
+script:
+    - command: "/etc/calamares/scripts/btrfs-installation-snapshot"
+    - "-rm /etc/calamares/scripts/btrfs-installation-snapshot"
+
+i18n:
+    name: "Creating Btrfs installation snapshot"

--- a/src/scripts/btrfs-installation-snapshot
+++ b/src/scripts/btrfs-installation-snapshot
@@ -1,19 +1,18 @@
 #!/bin/bash
 
-# Only proceed if root is on btrfs
-FSTYPE=$(findmnt -n -o FSTYPE /)
-if [ "$FSTYPE" != "btrfs" ]; then
-    exit 0
-fi
-
-# Only proceed if snapper root config exists
-if [ ! -f /etc/snapper/configs/root ]; then
+# Only proceed if cachyos-snapper-support is installed (present on all btrfs installs)
+if ! pacman -Qs cachyos-snapper-support > /dev/null 2>&1; then
     exit 0
 fi
 
 # Create installation snapshot with no cleanup algorithm so snapper
 # will never automatically delete it — used as a restore point.
-snapper --no-dbus -c root create \
+# --print-number outputs the snapshot ID so we can save it for later use
+# by restore tooling (e.g. snapper rollback).
+SNAP_ID=$(snapper --no-dbus -c root create --print-number \
     --cleanup-algorithm "" \
     --description "Fresh CachyOS Installation" \
-    --userdata "important=yes"
+    --userdata "important=yes")
+
+mkdir -p /etc/cachyos
+echo "$SNAP_ID" > /etc/cachyos/installation-snapshot

--- a/src/scripts/btrfs-installation-snapshot
+++ b/src/scripts/btrfs-installation-snapshot
@@ -5,12 +5,11 @@ if ! pacman -Qs cachyos-snapper-support > /dev/null 2>&1; then
     exit 0
 fi
 
-# Create installation snapshot with no cleanup algorithm so snapper
-# will never automatically delete it — used as a restore point.
+# Create installation snapshot — snapper defaults to no cleanup algorithm,
+# so this snapshot will never be automatically deleted. Used as a restore point.
 # --print-number outputs the snapshot ID so we can save it for later use
 # by restore tooling (e.g. snapper rollback).
 SNAP_ID=$(snapper --no-dbus -c root create --print-number \
-    --cleanup-algorithm "" \
     --description "Fresh CachyOS Installation" \
     --userdata "important=yes")
 

--- a/src/scripts/btrfs-installation-snapshot
+++ b/src/scripts/btrfs-installation-snapshot
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Only proceed if root is on btrfs
+FSTYPE=$(findmnt -n -o FSTYPE /)
+if [ "$FSTYPE" != "btrfs" ]; then
+    exit 0
+fi
+
+# Only proceed if snapper root config exists
+if [ ! -f /etc/snapper/configs/root ]; then
+    exit 0
+fi
+
+# Create installation snapshot with no cleanup algorithm so snapper
+# will never automatically delete it — used as a restore point.
+snapper --no-dbus -c root create \
+    --cleanup-algorithm "" \
+    --description "Fresh CachyOS Installation" \
+    --userdata "important=yes"


### PR DESCRIPTION
Add a shellprocess step that uses snapper to snapshot the freshly installed system right before unmounting the target. The snapshot is created with --cleanup-algorithm "" so snapper's number and timeline cleanup timers will never automatically remove it.

This can be used then to "reset" the installation but keeping the HOME directory. There needs to be some changes done, when making a reset so that we move the .config files to .config.bak before the users boots it, but this will be a future implementation