### PR TITLE
plymouthcfg: Use simpledrm by default to show splash screen

### DIFF
--- a/src/modules/plymouthcfg/main.py
+++ b/src/modules/plymouthcfg/main.py
@@ -12,8 +12,6 @@
 #   Calamares is Free Software: see the License-Identifier above.
 #
 
-import subprocess
-
 import libcalamares
 
 from libcalamares.utils import debug, target_env_call
@@ -39,25 +37,6 @@ def detect_plymouth():
     return target_env_call(["sh", "-c", "which plymouth"]) == 0
 
 
-def detect_amdgpu():
-    """
-    Checks if an AMD GPU is present using chwd.
-
-    @return True if an AMD GPU is detected, False otherwise
-    """
-    try:
-        result = subprocess.run(
-            ["chwd", "--check", "amd"],
-            capture_output=True, text=True
-        )
-        if result.returncode == 0:
-            debug("Detected AMD GPU via chwd")
-            return True
-    except OSError:
-        debug("Could not run chwd for AMD GPU detection")
-    return False
-
-
 class PlymouthController:
 
     def __init__(self):
@@ -68,14 +47,8 @@ class PlymouthController:
         return self.__root
 
     def setTheme(self):
-        config = libcalamares.job.configuration
-        plymouth_theme = config["plymouth_theme"]
-
-        if config.get("plymouth_theme_amdgpu") and detect_amdgpu():
-            plymouth_theme = config["plymouth_theme_amdgpu"]
-            debug("Using AMD GPU plymouth theme: {}".format(plymouth_theme))
-
-        target_env_call(["plymouth-set-default-theme", plymouth_theme])
+        plymouth_theme = libcalamares.job.configuration["plymouth_theme"]
+        target_env_call(["plymouth-set-default-theme",  plymouth_theme])
 
     def run(self):
         if detect_plymouth():

--- a/src/modules/plymouthcfg/main.py
+++ b/src/modules/plymouthcfg/main.py
@@ -12,9 +12,11 @@
 #   Calamares is Free Software: see the License-Identifier above.
 #
 
+import os
+import fileinput
 import libcalamares
 
-from libcalamares.utils import debug, target_env_call
+from libcalamares.utils import debug, warning, target_env_call
 
 import gettext
 _ = gettext.translation("calamares-python",
@@ -50,11 +52,28 @@ class PlymouthController:
         plymouth_theme = libcalamares.job.configuration["plymouth_theme"]
         target_env_call(["plymouth-set-default-theme",  plymouth_theme])
 
+    def setUseSimpledrm(self):
+        conf_path = os.path.join(self.__root, "etc", "plymouth", "plymouthd.conf")
+
+        try:
+            with fileinput.input(conf_path, inplace=True) as config:
+                for line in config:
+                    if line.startswith("#[Daemon]") or line.startswith("[Daemon]"):
+                        line = line.lstrip("#")
+                        line = line + "UseSimpledrm=1\n"
+
+                    print(line, end='')
+        except Exception as e:
+            warning("Failed to set UseSimpledrm=1: {!s}".format(e))
+
     def run(self):
         if detect_plymouth():
             if (("plymouth_theme" in libcalamares.job.configuration) and
                (libcalamares.job.configuration["plymouth_theme"] is not None)):
                 self.setTheme()
+
+            if libcalamares.job.configuration.get("plymouth_simpledrm", False):
+                self.setUseSimpledrm()
         return None
 
 

--- a/src/modules/plymouthcfg/main.py
+++ b/src/modules/plymouthcfg/main.py
@@ -13,10 +13,11 @@
 #
 
 import subprocess
-
+import os
+import fileinput
 import libcalamares
 
-from libcalamares.utils import debug, target_env_call
+from libcalamares.utils import debug, warning, target_env_call
 
 import gettext
 _ = gettext.translation("calamares-python",
@@ -77,11 +78,28 @@ class PlymouthController:
 
         target_env_call(["plymouth-set-default-theme", plymouth_theme])
 
+    def setUseSimpledrm(self):
+        conf_path = os.path.join(self.__root, "etc", "plymouth", "plymouthd.conf")
+
+        try:
+            with fileinput.input(conf_path, inplace=True) as config:
+                for line in config:
+                    if line.startswith("#[Daemon]") or line.startswith("[Daemon]"):
+                        line = line.lstrip("#")
+                        line = line + "UseSimpledrm=1\n"
+
+                    print(line, end='')
+        except Exception as e:
+            warning("Failed to set UseSimpledrm=1: {!s}".format(e))
+
     def run(self):
         if detect_plymouth():
             if (("plymouth_theme" in libcalamares.job.configuration) and
                (libcalamares.job.configuration["plymouth_theme"] is not None)):
                 self.setTheme()
+
+            if libcalamares.job.configuration.get("plymouth_simpledrm", False):
+                self.setUseSimpledrm()
         return None
 
 

--- a/src/modules/plymouthcfg/plymouthcfg.conf
+++ b/src/modules/plymouthcfg/plymouthcfg.conf
@@ -26,8 +26,6 @@
 
 plymouth_theme: cachyos-bootanimation
 
-# Optional: set a different theme for systems with AMD GPUs.
-# If an AMD GPU is detected and this is set, it overrides plymouth_theme.
-# Leave commented to use the same theme for all hardware.
-plymouth_theme_amdgpu: cachyos
+
+
 

--- a/src/modules/plymouthcfg/plymouthcfg.conf
+++ b/src/modules/plymouthcfg/plymouthcfg.conf
@@ -3,20 +3,20 @@
 #
 # Plymouth Configuration Module
 #
-# This module can be used to setup the default plymouth theme to 
+# This module can be used to setup the default plymouth theme to
 # be used with your distribution
 #
-# You should only use this module if the plymouth package is installed 
-# on the build configurations of your distribution & the plymouth 
+# You should only use this module if the plymouth package is installed
+# on the build configurations of your distribution & the plymouth
 # theme you want to configure is installed as well. If the unpacked
 # filesystem configures a plymouth theme already, there is no need
 # to change it here.
 ---
 
 
-# Leave this commented if you want to use the default theme 
-# shipped with your distribution configurations. Make sure that 
-# the theme exists in the themes directory of plymouth path. 
+# Leave this commented if you want to use the default theme
+# shipped with your distribution configurations. Make sure that
+# the theme exists in the themes directory of plymouth path.
 # Debian / Ubuntu comes with themes "joy", "script", "softwaves",
 # possibly others. Look in /usr/share/plymouth/themes for more.
 #
@@ -26,6 +26,5 @@
 
 plymouth_theme: cachyos-bootanimation
 
-
-
-
+# Use simpledrm driver to show splash screen
+plymouth_simpledrm: true

--- a/src/modules/plymouthcfg/plymouthcfg.conf
+++ b/src/modules/plymouthcfg/plymouthcfg.conf
@@ -3,20 +3,20 @@
 #
 # Plymouth Configuration Module
 #
-# This module can be used to setup the default plymouth theme to 
+# This module can be used to setup the default plymouth theme to
 # be used with your distribution
 #
-# You should only use this module if the plymouth package is installed 
-# on the build configurations of your distribution & the plymouth 
+# You should only use this module if the plymouth package is installed
+# on the build configurations of your distribution & the plymouth
 # theme you want to configure is installed as well. If the unpacked
 # filesystem configures a plymouth theme already, there is no need
 # to change it here.
 ---
 
 
-# Leave this commented if you want to use the default theme 
-# shipped with your distribution configurations. Make sure that 
-# the theme exists in the themes directory of plymouth path. 
+# Leave this commented if you want to use the default theme
+# shipped with your distribution configurations. Make sure that
+# the theme exists in the themes directory of plymouth path.
 # Debian / Ubuntu comes with themes "joy", "script", "softwaves",
 # possibly others. Look in /usr/share/plymouth/themes for more.
 #
@@ -31,3 +31,5 @@ plymouth_theme: cachyos-bootanimation
 # Leave commented to use the same theme for all hardware.
 plymouth_theme_amdgpu: cachyos
 
+# Use simpledrm driver to show splash screen
+plymouth_simpledrm: true

--- a/src/modules/plymouthcfg/plymouthcfg.schema.yaml
+++ b/src/modules/plymouthcfg/plymouthcfg.schema.yaml
@@ -7,4 +7,3 @@ additionalProperties: false
 type: object
 properties:
     plymouth_theme: { type: string }
-    plymouth_theme_amdgpu: { type: string }

--- a/src/modules/plymouthcfg/plymouthcfg.schema.yaml
+++ b/src/modules/plymouthcfg/plymouthcfg.schema.yaml
@@ -7,3 +7,4 @@ additionalProperties: false
 type: object
 properties:
     plymouth_theme: { type: string }
+    plymouth_simpledrm: { type: boolean }

--- a/src/modules/plymouthcfg/plymouthcfg.schema.yaml
+++ b/src/modules/plymouthcfg/plymouthcfg.schema.yaml
@@ -8,3 +8,4 @@ type: object
 properties:
     plymouth_theme: { type: string }
     plymouth_theme_amdgpu: { type: string }
+    plymouth_simpledrm: { type: boolean }


### PR DESCRIPTION
Needed for: https://github.com/CachyOS/chwd/pull/236
See https://fedoraproject.org/wiki/Changes/PlymouthUseSimpledrm for more details.