### PR TITLE
Remove iptables-nft from pacstrap configuration

### DIFF
--- a/src/modules/pacstrap/pacstrap.conf
+++ b/src/modules/pacstrap/pacstrap.conf
@@ -30,7 +30,6 @@ basePackages:
   - exfatprogs
   - f2fs-tools
   - inetutils
-  - iptables-nft
   - jfsutils
   - less
   - linux-cachyos


### PR DESCRIPTION
`iptables-nft` is deprecated for `iptables` which needs no explicit dep as its required by `iproute2` which is needed by `base`.

