### PR TITLE
netinstall: Add new cachyos-gnome-settings

### DIFF
--- a/src/modules/netinstall/netinstall.yaml
+++ b/src/modules/netinstall/netinstall.yaml
@@ -234,6 +234,7 @@
   selected: false
   critical: true
   packages:
+    - cachyos-gnome-settings
     - cachy-update
     - fwupd
     - gdm


### PR DESCRIPTION
Installer `cachyos-gnome-settings` re-integration for future maintainability of GNOME on CachyOS. My updated `cachyos-gnome-settings` package appears to now be available in repos as of yesterday, so this should be the final step.