### PR TITLE
keyboard: fix Wayland layout switching

### DIFF
--- a/src/modules/keyboard/Config.cpp
+++ b/src/modules/keyboard/Config.cpp
@@ -22,10 +22,13 @@
 #include "utils/Variant.h"
 
 #include <QApplication>
+#include <QDir>
 #include <QFile>
+#include <QFileInfo>
 #include <QGuiApplication>
 #include <QProcess>
 #include <QRegularExpression>
+#include <QSettings>
 #include <QStandardPaths>
 #include <QTimer>
 
@@ -117,6 +120,28 @@ xkbmap_query_grp_option()
     int lastIndex = outputLine.indexOf( QRegularExpression( "[\\s,]" ), index );
 
     return outputLine.mid( index, lastIndex - index );
+}
+
+static void
+ensureGroupSwitcher( const BasicLayoutInfo& settings, AdditionalLayoutInfo& extra )
+{
+    if ( extra.additionalLayout.isEmpty() )
+    {
+        return;
+    }
+
+    if ( !settings.selectedGroup.isEmpty() )
+    {
+        extra.groupSwitcher = "grp:" + settings.selectedGroup;
+    }
+    if ( extra.groupSwitcher.isEmpty() )
+    {
+        extra.groupSwitcher = xkbmap_query_grp_option();
+    }
+    if ( extra.groupSwitcher.isEmpty() )
+    {
+        extra.groupSwitcher = "grp:alt_shift_toggle";
+    }
 }
 
 AdditionalLayoutInfo
@@ -230,23 +255,11 @@ applyXkb( const BasicLayoutInfo& settings, AdditionalLayoutInfo& extra )
     QStringList basicArguments = xkbmap_model_args( settings.selectedModel );
     if ( !extra.additionalLayout.isEmpty() )
     {
-        if ( !settings.selectedGroup.isEmpty() )
-        {
-            extra.groupSwitcher = "grp:" + settings.selectedGroup;
-        }
-
-        if ( extra.groupSwitcher.isEmpty() )
-        {
-            extra.groupSwitcher = xkbmap_query_grp_option();
-        }
-        if ( extra.groupSwitcher.isEmpty() )
-        {
-            extra.groupSwitcher = "grp:alt_shift_toggle";
-        }
+        ensureGroupSwitcher( settings, extra );
 
         basicArguments.append(
-            xkbmap_layout_args_with_group_switch( { extra.additionalLayout, settings.selectedLayout },
-                                                  { extra.additionalVariant, settings.selectedVariant },
+            xkbmap_layout_args_with_group_switch( { settings.selectedLayout, extra.additionalLayout },
+                                                  { settings.selectedVariant, extra.additionalVariant },
                                                   extra.groupSwitcher ) );
         QProcess::execute( "setxkbmap", basicArguments );
 
@@ -271,8 +284,10 @@ applyLocale1( const BasicLayoutInfo& settings, AdditionalLayoutInfo& extra )
 
     if ( !extra.additionalLayout.isEmpty() )
     {
-        layout = extra.additionalLayout + "," + layout;
-        variant = extra.additionalVariant + "," + variant;
+        ensureGroupSwitcher( settings, extra );
+
+        layout = layout + "," + extra.additionalLayout;
+        variant = variant + "," + extra.additionalVariant;
         option = extra.groupSwitcher;
     }
 
@@ -297,58 +312,40 @@ applyLocale1( const BasicLayoutInfo& settings, AdditionalLayoutInfo& extra )
     }
 }
 
-// In a config-file's list of lines, replace lines <key>=<something> by <key>=<value>
-static void
-replaceKey( QStringList& content, const QString& key, const QString& value )
-{
-    for ( int i = 0; i < content.length(); ++i )
-    {
-        if ( content.at( i ).startsWith( key ) )
-        {
-            content[ i ] = key + value;
-        }
-    }
-}
-
 static bool
-rewriteKWin( const QString& path, const QString& model, const QString& layouts, const QString& variants )
+writeKWin( const QString& path,
+           const QString& model,
+           const QString& layouts,
+           const QString& variants,
+           const QString& options )
 {
-    if ( !QFile::exists( path ) )
+    const QFileInfo fileInfo( path );
+    if ( !QDir().mkpath( fileInfo.absolutePath() ) )
     {
         return false;
     }
 
-    QFile config( path );
-    if ( !config.open( QIODevice::ReadOnly ) )
+    QSettings config( path, QSettings::IniFormat );
+    config.beginGroup( QStringLiteral( "Layout" ) );
+    config.setValue( QStringLiteral( "Use" ), true );
+    config.setValue( QStringLiteral( "Model" ), model );
+    config.setValue( QStringLiteral( "LayoutList" ), layouts );
+    config.setValue( QStringLiteral( "VariantList" ), variants );
+    if ( !options.isEmpty() )
     {
-        return false;
+        config.setValue( QStringLiteral( "ResetOldOptions" ), true );
+        config.setValue( QStringLiteral( "Options" ), options );
     }
-    QStringList content = []( QFile& f )
-    {
-        QTextStream s( &f );
-        return s.readAll().split( '\n' );
-    }( config );
-    config.close();
+    config.endGroup();
+    config.sync();
 
-    if ( !config.open( QIODevice::WriteOnly ) )
-    {
-        return false;
-    }
-
-    replaceKey( content, QStringLiteral( "Model=" ), model );
-    replaceKey( content, QStringLiteral( "LayoutList=" ), layouts );
-    replaceKey( content, QStringLiteral( "VariantList=" ), variants );
-
-    config.write( content.join( '\n' ).toUtf8() );
-    config.close();
-
-    return true;
+    return config.status() == QSettings::NoError;
 }
 
 void
 applyKWin( const BasicLayoutInfo& settings, AdditionalLayoutInfo& extra )
 {
-    const auto paths = QStandardPaths::standardLocations( QStandardPaths::ConfigLocation );
+    ensureGroupSwitcher( settings, extra );
 
     auto join = [ &additional = extra.additionalLayout ]( const QString& s1, const QString& s2 )
     { return additional.isEmpty() ? s1 : QStringLiteral( "%1,%2" ).arg( s1, s2 ); };
@@ -356,23 +353,23 @@ applyKWin( const BasicLayoutInfo& settings, AdditionalLayoutInfo& extra )
     const QString layouts = join( settings.selectedLayout, extra.additionalLayout );
     const QString variants = join( settings.selectedVariant, extra.additionalVariant );
 
-    bool updated = false;
-    for ( const auto& path : paths )
+    const QString configPath = QStandardPaths::writableLocation( QStandardPaths::ConfigLocation );
+    if ( configPath.isEmpty() )
     {
-        const QString candidate = path + QStringLiteral( "/kxkbrc" );
-        if ( rewriteKWin( candidate, settings.selectedModel, layouts, variants ) )
-        {
-            updated = true;
-            break;
-        }
+        return;
+    }
+    if ( !writeKWin( configPath + QStringLiteral( "/kxkbrc" ),
+                     settings.selectedModel,
+                     layouts,
+                     variants,
+                     extra.groupSwitcher ) )
+    {
+        return;
     }
 
-    if ( updated )
-    {
-        auto kwin = QDBusMessage::createSignal(
-            QStringLiteral( "/Layouts" ), QStringLiteral( "org.kde.keyboard" ), QStringLiteral( "reloadConfig" ) );
-        QDBusConnection::sessionBus().send( kwin );
-    }
+    auto kwin = QDBusMessage::createSignal(
+        QStringLiteral( "/Layouts" ), QStringLiteral( "org.kde.keyboard" ), QStringLiteral( "reloadConfig" ) );
+    QDBusConnection::sessionBus().send( kwin );
 }
 
 QString
@@ -415,19 +412,7 @@ applyGnome( const BasicLayoutInfo& settings, AdditionalLayoutInfo& extra )
     // gsettings set org.gnome.desktop.input-sources xkb-options "['grp:lalt_lshift_toggle']"
     if ( !extra.additionalLayout.isEmpty() )
     {
-        // Get a reasonable value for the group switcher, defaulting to alt_shift_toggle if nothing else is set
-        if ( !settings.selectedGroup.isEmpty() )
-        {
-            extra.groupSwitcher = "grp:" + settings.selectedGroup;
-        }
-        if ( extra.groupSwitcher.isEmpty() )
-        {
-            extra.groupSwitcher = xkbmap_query_grp_option();
-        }
-        if ( extra.groupSwitcher.isEmpty() )
-        {
-            extra.groupSwitcher = "grp:alt_shift_toggle";
-        }
+        ensureGroupSwitcher( settings, extra );
 
         const QString xkbOptionsValue = QStringLiteral( "['%1']" ).arg( extra.groupSwitcher );
         const QStringList xkbOptionsCommand = QStringList( sudoArguments ) << "xkb-options" << xkbOptionsValue;
@@ -448,6 +433,7 @@ void
 Config::apply()
 {
     m_additionalLayoutInfo = getAdditionalLayoutInfo( m_current.selectedLayout );
+    ensureGroupSwitcher( m_current, m_additionalLayoutInfo );
     if ( m_configureXkb )
     {
         applyXkb( m_current, m_additionalLayoutInfo );
@@ -692,6 +678,8 @@ Calamares::JobList
 Config::createJobs()
 {
     QList< Calamares::job_ptr > list;
+    m_additionalLayoutInfo = getAdditionalLayoutInfo( m_current.selectedLayout );
+    ensureGroupSwitcher( m_current, m_additionalLayoutInfo );
 
     Calamares::Job* j = new SetKeyboardLayoutJob( m_current.selectedModel,
                                                   m_current.selectedLayout,
@@ -700,6 +688,7 @@ Config::createJobs()
                                                   m_xOrgConfFileName,
                                                   m_convertedKeymapPath,
                                                   m_configureEtcDefaultKeyboard,
+                                                  m_configureKWin,
                                                   m_configureLocale1 );
     list.append( Calamares::job_ptr( j ) );
 
@@ -842,6 +831,9 @@ void
 Config::finalize()
 {
     Calamares::GlobalStorage* gs = Calamares::JobQueue::instance()->globalStorage();
+    m_additionalLayoutInfo = getAdditionalLayoutInfo( m_current.selectedLayout );
+    ensureGroupSwitcher( m_current, m_additionalLayoutInfo );
+
     if ( !m_current.selectedLayout.isEmpty() )
     {
         gs->insert( "keyboardLayout", m_current.selectedLayout );

--- a/src/modules/keyboard/SetKeyboardLayoutJob.cpp
+++ b/src/modules/keyboard/SetKeyboardLayoutJob.cpp
@@ -32,10 +32,19 @@
 namespace
 {
 QStringList
-removeEmpty( QStringList&& list )
+layoutsForConfig( const QString& layout, const AdditionalLayoutInfo& additionalLayoutInfo )
 {
-    list.removeAll( QString() );
-    return list;
+    return additionalLayoutInfo.additionalLayout.isEmpty()
+        ? QStringList { layout }
+        : QStringList { layout, additionalLayoutInfo.additionalLayout };
+}
+
+QStringList
+variantsForConfig( const QString& variant, const AdditionalLayoutInfo& additionalLayoutInfo )
+{
+    return additionalLayoutInfo.additionalLayout.isEmpty()
+        ? QStringList { variant }
+        : QStringList { variant, additionalLayoutInfo.additionalVariant };
 }
 }  // namespace
 
@@ -46,6 +55,7 @@ SetKeyboardLayoutJob::SetKeyboardLayoutJob( const QString& model,
                                             const QString& xOrgConfFileName,
                                             const QString& convertedKeymapPath,
                                             bool writeEtcDefaultKeyboard,
+                                            bool writeKdeKeyboardConfig,
                                             bool skipIfNoRoot )
     : Calamares::Job()
     , m_model( model )
@@ -55,6 +65,7 @@ SetKeyboardLayoutJob::SetKeyboardLayoutJob( const QString& model,
     , m_xOrgConfFileName( xOrgConfFileName )
     , m_convertedKeymapPath( convertedKeymapPath )
     , m_writeEtcDefaultKeyboard( writeEtcDefaultKeyboard )
+    , m_writeKdeKeyboardConfig( writeKdeKeyboardConfig )
     , m_skipIfNoRoot( skipIfNoRoot )
 {
 }
@@ -279,8 +290,8 @@ SetKeyboardLayoutJob::writeX11Data( const QString& keyboardConfPath ) const
               "        MatchIsKeyboard \"on\"\n";
 
 
-    const QStringList layouts = removeEmpty( { m_additionalLayoutInfo.additionalLayout, m_layout } );
-    const QStringList variants = removeEmpty( { m_additionalLayoutInfo.additionalVariant, m_variant } );
+    const QStringList layouts = layoutsForConfig( m_layout, m_additionalLayoutInfo );
+    const QStringList variants = variantsForConfig( m_variant, m_additionalLayoutInfo );
     stream << "        Option \"XkbLayout\" \"" << layouts.join( "," ) << "\"\n";
     stream << "        Option \"XkbVariant\" \"" << variants.join( "," ) << "\"\n";
     if ( !m_additionalLayoutInfo.additionalLayout.isEmpty() )
@@ -313,8 +324,8 @@ SetKeyboardLayoutJob::writeDefaultKeyboardData( const QString& defaultKeyboardPa
     }
     QTextStream stream( &file );
 
-    const QStringList layouts = removeEmpty( { m_additionalLayoutInfo.additionalLayout, m_layout } );
-    const QStringList variants = removeEmpty( { m_additionalLayoutInfo.additionalVariant, m_variant } );
+    const QStringList layouts = layoutsForConfig( m_layout, m_additionalLayoutInfo );
+    const QStringList variants = variantsForConfig( m_variant, m_additionalLayoutInfo );
     stream << "# KEYBOARD CONFIGURATION FILE\n\n"
               "# Consult the keyboard(5) manual page.\n\n";
 
@@ -337,6 +348,55 @@ SetKeyboardLayoutJob::writeDefaultKeyboardData( const QString& defaultKeyboardPa
     return ( stream.status() == QTextStream::Ok );
 }
 
+static bool
+writeKdeKeyboardData( const QString& kxkbPath,
+                      const QString& model,
+                      const QString& layout,
+                      const QString& variant,
+                      const AdditionalLayoutInfo& additionalLayoutInfo )
+{
+    cDebug() << "Writing KDE keyboard data to" << kxkbPath;
+
+    const QFileInfo fileInfo( kxkbPath );
+    if ( !QDir().mkpath( fileInfo.absolutePath() ) )
+    {
+        cError() << "Could not create" << fileInfo.absolutePath() << "for KDE keyboard configuration.";
+        return false;
+    }
+
+    QSettings config( kxkbPath, QSettings::IniFormat );
+    const QStringList layouts = layoutsForConfig( layout, additionalLayoutInfo );
+    const QStringList variants = variantsForConfig( variant, additionalLayoutInfo );
+
+    config.beginGroup( QStringLiteral( "Layout" ) );
+    config.setValue( QStringLiteral( "Use" ), true );
+    config.setValue( QStringLiteral( "Model" ), model );
+    config.setValue( QStringLiteral( "LayoutList" ), layouts.join( "," ) );
+    config.setValue( QStringLiteral( "VariantList" ), variants.join( "," ) );
+    if ( additionalLayoutInfo.groupSwitcher.isEmpty() )
+    {
+        config.remove( QStringLiteral( "Options" ) );
+        config.remove( QStringLiteral( "ResetOldOptions" ) );
+    }
+    else
+    {
+        config.setValue( QStringLiteral( "ResetOldOptions" ), true );
+        config.setValue( QStringLiteral( "Options" ), additionalLayoutInfo.groupSwitcher );
+    }
+    config.endGroup();
+    config.sync();
+
+    if ( config.status() != QSettings::NoError )
+    {
+        cError() << "Could not write KDE keyboard configuration to" << kxkbPath;
+        return false;
+    }
+
+    cDebug() << Logger::SubEntry << "Written KDE LayoutList" << layouts.join( "," ) << "; Model" << model
+             << "; VariantList" << variants.join( "," ) << "to" << kxkbPath;
+    return true;
+}
+
 
 Calamares::JobResult
 SetKeyboardLayoutJob::exec()
@@ -346,10 +406,11 @@ SetKeyboardLayoutJob::exec()
     // the global settings
     Calamares::GlobalStorage* gs = Calamares::JobQueue::instance()->globalStorage();
     QDir destDir( gs->value( "rootMountPoint" ).toString() );
+    const bool skipLocalRoot = m_skipIfNoRoot && ( destDir.isEmpty() || destDir.isRoot() );
 
     // Skip this if we are using locale1 and we are configuring the local system,
     // since the service will have already updated these configs for us.
-    if ( !( m_skipIfNoRoot && ( destDir.isEmpty() || destDir.isRoot() ) ) )
+    if ( !skipLocalRoot )
     {
         // Get the path to the destination's /etc/vconsole.conf
         QString vconsoleConfPath = destDir.absoluteFilePath( "etc/vconsole.conf" );
@@ -416,6 +477,17 @@ SetKeyboardLayoutJob::exec()
                     tr( "Failed to write keyboard configuration to existing /etc/default directory.", "@error" ),
                     tr( "Failed to write to %1", "@error, %1 is default keyboard path" ).arg( defaultKeyboardPath ) );
             }
+        }
+    }
+
+    if ( m_writeKdeKeyboardConfig && !skipLocalRoot && QDir( destDir.absoluteFilePath( "etc/skel" ) ).exists() )
+    {
+        const QString kdeKeyboardPath = destDir.absoluteFilePath( "etc/skel/.config/kxkbrc" );
+        if ( !writeKdeKeyboardData( kdeKeyboardPath, m_model, m_layout, m_variant, m_additionalLayoutInfo ) )
+        {
+            return Calamares::JobResult::error(
+                tr( "Failed to write keyboard configuration for KDE Plasma.", "@error" ),
+                tr( "Failed to write to %1", "@error, %1 is KDE keyboard configuration path" ).arg( kdeKeyboardPath ) );
         }
     }
 

--- a/src/modules/keyboard/SetKeyboardLayoutJob.h
+++ b/src/modules/keyboard/SetKeyboardLayoutJob.h
@@ -26,6 +26,7 @@ public:
                           const QString& xOrgConfFileName,
                           const QString& convertedKeymapPath,
                           bool writeEtcDefaultKeyboard,
+                          bool writeKdeKeyboardConfig,
                           bool skipIfNoRoot );
 
     QString prettyName() const override;
@@ -45,6 +46,7 @@ private:
     QString m_xOrgConfFileName;
     QString m_convertedKeymapPath;
     const bool m_writeEtcDefaultKeyboard;
+    const bool m_writeKdeKeyboardConfig;
     const bool m_skipIfNoRoot;
 };
 


### PR DESCRIPTION
Populate the locale1 group switcher for non-ASCII layouts, keep the selected layout active before the ASCII fallback, and persist KDE keyboard settings only when KWin configuration is enabled on an installed target.

Fixes: https://github.com/CachyOS/distribution/issues/428