### PR TITLE
netinstall: change gnome system monitor to Resources

### DIFF
--- a/src/modules/netinstall/netinstall.yaml
+++ b/src/modules/netinstall/netinstall.yaml
@@ -275,7 +275,7 @@
           - gnome-disk-utility
           - gnome-power-manager
           - gnome-calculator
-          - gnome-system-monitor
+          - resources
           - baobab
           - malcontent
           - showtime


### PR DESCRIPTION
The newer GNOME Resources app has much more coverage than gnome-system-monitor, and is now more actively developed. As of GNOME 51 (and already on Ubuntu), this is being shipped as the new default system monitor.
