### PR TITLE
keyboard: put selected layout first and seed KDE skel config

### DIFF
--- a/src/modules/keyboard/Config.cpp
+++ b/src/modules/keyboard/Config.cpp
@@ -259,8 +259,8 @@ applyXkb( const BasicLayoutInfo& settings, AdditionalLayoutInfo& extra )
     {
         prepareGroupSwitcher( settings, extra );
         basicArguments.append(
-            xkbmap_layout_args_with_group_switch( { extra.additionalLayout, settings.selectedLayout },
-                                                  { extra.additionalVariant, settings.selectedVariant },
+            xkbmap_layout_args_with_group_switch( { settings.selectedLayout, extra.additionalLayout },
+                                                  { settings.selectedVariant, extra.additionalVariant },
                                                   extra.groupSwitcher ) );
         QProcess::execute( "setxkbmap", basicArguments );
 
@@ -286,8 +286,8 @@ applyLocale1( const BasicLayoutInfo& settings, AdditionalLayoutInfo& extra )
     if ( !extra.additionalLayout.isEmpty() )
     {
         prepareGroupSwitcher( settings, extra );
-        layout = extra.additionalLayout + "," + layout;
-        variant = extra.additionalVariant + "," + variant;
+        layout = layout + "," + extra.additionalLayout;
+        variant = variant + "," + extra.additionalVariant;
         option = extra.groupSwitcher;
     }
 
@@ -412,11 +412,11 @@ applyKWin( const BasicLayoutInfo& settings, AdditionalLayoutInfo& extra )
     const auto paths = QStandardPaths::standardLocations( QStandardPaths::ConfigLocation );
     prepareGroupSwitcher( settings, extra );
 
-    auto join = [ &additional = extra.additionalLayout ]( const QString& additionalValue, const QString& selectedValue )
-    { return additional.isEmpty() ? selectedValue : QStringLiteral( "%1,%2" ).arg( additionalValue, selectedValue ); };
+    auto join = [ &additional = extra.additionalLayout ]( const QString& selectedValue, const QString& additionalValue )
+    { return additional.isEmpty() ? selectedValue : QStringLiteral( "%1,%2" ).arg( selectedValue, additionalValue ); };
 
-    const QString layouts = join( extra.additionalLayout, settings.selectedLayout );
-    const QString variants = join( extra.additionalVariant, settings.selectedVariant );
+    const QString layouts = join( settings.selectedLayout, extra.additionalLayout );
+    const QString variants = join( settings.selectedVariant, extra.additionalVariant );
     const QString options = extra.groupSwitcher;
 
     bool updated = false;
@@ -745,6 +745,8 @@ Calamares::JobList
 Config::createJobs()
 {
     QList< Calamares::job_ptr > list;
+    m_additionalLayoutInfo = getAdditionalLayoutInfo( m_current.selectedLayout );
+    prepareGroupSwitcher( m_current, m_additionalLayoutInfo );
 
     Calamares::Job* j = new SetKeyboardLayoutJob( m_current.selectedModel,
                                                   m_current.selectedLayout,
@@ -753,6 +755,7 @@ Config::createJobs()
                                                   m_xOrgConfFileName,
                                                   m_convertedKeymapPath,
                                                   m_configureEtcDefaultKeyboard,
+                                                  m_configureKWin,
                                                   m_configureLocale1 );
     list.append( Calamares::job_ptr( j ) );
 

--- a/src/modules/keyboard/SetKeyboardLayoutJob.cpp
+++ b/src/modules/keyboard/SetKeyboardLayoutJob.cpp
@@ -48,7 +48,7 @@ variantList( const AdditionalLayoutInfo& additionalLayoutInfo, const QString& va
         return removeEmpty( { variant } );
     }
 
-    QStringList variants { additionalLayoutInfo.additionalVariant, variant };
+    QStringList variants { variant, additionalLayoutInfo.additionalVariant };
     if ( variants.join( QString() ).isEmpty() )
     {
         variants.clear();
@@ -63,6 +63,7 @@ SetKeyboardLayoutJob::SetKeyboardLayoutJob( const QString& model,
                                             const QString& xOrgConfFileName,
                                             const QString& convertedKeymapPath,
                                             bool writeEtcDefaultKeyboard,
+                                            bool writeKdeKeyboardConfig,
                                             bool skipIfNoRoot )
     : Calamares::Job()
     , m_model( model )
@@ -72,6 +73,7 @@ SetKeyboardLayoutJob::SetKeyboardLayoutJob( const QString& model,
     , m_xOrgConfFileName( xOrgConfFileName )
     , m_convertedKeymapPath( convertedKeymapPath )
     , m_writeEtcDefaultKeyboard( writeEtcDefaultKeyboard )
+    , m_writeKdeKeyboardConfig( writeKdeKeyboardConfig )
     , m_skipIfNoRoot( skipIfNoRoot )
 {
 }
@@ -296,7 +298,7 @@ SetKeyboardLayoutJob::writeX11Data( const QString& keyboardConfPath ) const
               "        MatchIsKeyboard \"on\"\n";
 
 
-    const QStringList layouts = removeEmpty( { m_additionalLayoutInfo.additionalLayout, m_layout } );
+    const QStringList layouts = removeEmpty( { m_layout, m_additionalLayoutInfo.additionalLayout } );
     const QStringList variants = variantList( m_additionalLayoutInfo, m_variant );
     stream << "        Option \"XkbLayout\" \"" << layouts.join( "," ) << "\"\n";
     stream << "        Option \"XkbVariant\" \"" << variants.join( "," ) << "\"\n";
@@ -330,7 +332,7 @@ SetKeyboardLayoutJob::writeDefaultKeyboardData( const QString& defaultKeyboardPa
     }
     QTextStream stream( &file );
 
-    const QStringList layouts = removeEmpty( { m_additionalLayoutInfo.additionalLayout, m_layout } );
+    const QStringList layouts = removeEmpty( { m_layout, m_additionalLayoutInfo.additionalLayout } );
     const QStringList variants = variantList( m_additionalLayoutInfo, m_variant );
     stream << "# KEYBOARD CONFIGURATION FILE\n\n"
               "# Consult the keyboard(5) manual page.\n\n";
@@ -352,6 +354,35 @@ SetKeyboardLayoutJob::writeDefaultKeyboardData( const QString& defaultKeyboardPa
              << stream.status();
 
     return ( stream.status() == QTextStream::Ok );
+}
+
+static bool
+writeKdeKeyboardData( const QString& kxkbPath,
+                      const QString& model,
+                      const QString& layout,
+                      const QString& variant,
+                      const AdditionalLayoutInfo& additionalLayoutInfo )
+{
+    QDir().mkpath( QFileInfo( kxkbPath ).absolutePath() );
+
+    QSettings config( kxkbPath, QSettings::IniFormat );
+    const QStringList layouts = removeEmpty( { layout, additionalLayoutInfo.additionalLayout } );
+    const QStringList variants = variantList( additionalLayoutInfo, variant );
+
+    config.beginGroup( QStringLiteral( "Layout" ) );
+    config.setValue( QStringLiteral( "Use" ), true );
+    config.setValue( QStringLiteral( "Model" ), model );
+    config.setValue( QStringLiteral( "LayoutList" ), layouts.join( "," ) );
+    config.setValue( QStringLiteral( "VariantList" ), variants.join( "," ) );
+    if ( !additionalLayoutInfo.additionalLayout.isEmpty() )
+    {
+        config.setValue( QStringLiteral( "ResetOldOptions" ), true );
+        config.setValue( QStringLiteral( "Options" ), additionalLayoutInfo.groupSwitcher );
+    }
+    config.endGroup();
+    config.sync();
+
+    return config.status() == QSettings::NoError;
 }
 
 
@@ -432,6 +463,21 @@ SetKeyboardLayoutJob::exec()
                 return Calamares::JobResult::error(
                     tr( "Failed to write keyboard configuration to existing /etc/default directory.", "@error" ),
                     tr( "Failed to write to %1", "@error, %1 is default keyboard path" ).arg( defaultKeyboardPath ) );
+            }
+        }
+    }
+
+    if ( m_writeKdeKeyboardConfig && !( m_skipIfNoRoot && ( destDir.isEmpty() || destDir.isRoot() ) ) )
+    {
+        QDir skelDir( destDir.absoluteFilePath( "etc/skel" ) );
+        if ( skelDir.exists() )
+        {
+            QString kdeKeyboardPath = skelDir.absoluteFilePath( ".config/kxkbrc" );
+            if ( !writeKdeKeyboardData( kdeKeyboardPath, m_model, m_layout, m_variant, m_additionalLayoutInfo ) )
+            {
+                return Calamares::JobResult::error(
+                    tr( "Failed to write keyboard configuration for KDE Plasma.", "@error" ),
+                    tr( "Failed to write to %1", "@error, %1 is KDE keyboard configuration path" ).arg( kdeKeyboardPath ) );
             }
         }
     }

--- a/src/modules/keyboard/SetKeyboardLayoutJob.h
+++ b/src/modules/keyboard/SetKeyboardLayoutJob.h
@@ -26,6 +26,7 @@ public:
                           const QString& xOrgConfFileName,
                           const QString& convertedKeymapPath,
                           bool writeEtcDefaultKeyboard,
+                          bool writeKdeKeyboardConfig,
                           bool skipIfNoRoot );
 
     QString prettyName() const override;
@@ -45,6 +46,7 @@ private:
     QString m_xOrgConfFileName;
     QString m_convertedKeymapPath;
     const bool m_writeEtcDefaultKeyboard;
+    const bool m_writeKdeKeyboardConfig;
     const bool m_skipIfNoRoot;
 };
 

--- a/src/modules/keyboard/Tests.cpp
+++ b/src/modules/keyboard/Tests.cpp
@@ -80,10 +80,10 @@ KeyboardLayoutTests::testVariantList_data()
                                                                 << QStringList { QStringLiteral( "dvorak" ) };
     QTest::newRow( "additional layout with selected variant" ) << QStringLiteral( "us" ) << QString()
                                                               << QStringLiteral( "phonetic" )
-                                                              << QStringList { QString(), QStringLiteral( "phonetic" ) };
+                                                              << QStringList { QStringLiteral( "phonetic" ), QString() };
     QTest::newRow( "additional layout with additional variant" ) << QStringLiteral( "us" ) << QStringLiteral( "intl" )
                                                                 << QString()
-                                                                << QStringList { QStringLiteral( "intl" ), QString() };
+                                                                << QStringList { QString(), QStringLiteral( "intl" ) };
     QTest::newRow( "additional layout with no variants" ) << QStringLiteral( "us" ) << QString() << QString()
                                                           << QStringList {};
 }


### PR DESCRIPTION
Use the user's chosen layout as XKB group 1 everywhere (live apply, locale1, KWin, and install-time files) so non-ASCII layouts default correctly with US as the fallback. Refresh additional layout info and group-switch options in createJobs(), and write etc/skel/.config/kxkbrc during install when configure.kwin is enabled.