### PR TITLE
firewall: ufw and KDE Connect are installed, automatically add KDEC to ufw

### DIFF
--- a/src/scripts/enable-ufw
+++ b/src/scripts/enable-ufw
@@ -4,4 +4,9 @@ if pacman -Qs ufw > /dev/null ; then
   ufw default deny incoming
   ufw default allow outgoing
   ufw enable
+
+  if pacman -Qq kdeconnect > /dev/null ; then
+    ufw allow "KDE Connect"
+  fi
+
 fi


### PR DESCRIPTION
Installing the "KDE-Desktop" category installs KDE Connect. Installing "Firewall support" (checked by default) installs & configures ufw. Part of that configuration blocks all incoming connections:

https://github.com/CachyOS/cachyos-calamares/blob/8b580f78804cda1bccddc095cdedeb5019fea75d/src/scripts/enable-ufw#L4

This makes KDE Connect no longer work (devices just won't show up at all, without any error message). To save the user the time of

1. figuring out the cause of the problem being a connection issue
2. figuring out they have ufw ("Firewall support" is a sub-category, so the user might not consciously enable it)
3. figuring out how to configure ufw to avoid the problem

, check if both ufw and kdeconnect are installed after installation, and un-block KDE Connect if so.

---

Please check this PR carefully. I don't really know what the workflow is for testing a change like this, and as such this is untested. I've tried to follow the patterns I've seen from other "shellprocess" entries, but I could've missed some crucial step of course. No AI was used in the creation of this PR.