### PR TITLE
netinstall: add thumbnailers and print-manager for desktop printing

### DIFF
--- a/src/modules/netinstall/netinstall.yaml
+++ b/src/modules/netinstall/netinstall.yaml
@@ -88,6 +88,7 @@
           - accountsservice
           - bash-completion
           - ffmpegthumbnailer
+          - gnome-epub-thumbnailer
           - gst-libav
           - gst-plugin-pipewire
           - gst-plugins-bad
@@ -96,6 +97,7 @@
           - libgsf
           - libopenraw
           - plocate
+          - papers
           - poppler-glib
           - vlc-plugins-all
           - xdg-user-dirs
@@ -813,6 +815,7 @@
     - ghostscript
     - gsfonts
     - gutenprint
+    - print-manager
     - system-config-printer
 - name: "Support for HP Printer/Scanner"
   description: "Extra Packages for HP Printer/Scanner"


### PR DESCRIPTION
Install gnome-epub-thumbnailer and papers with default desktop integration so PDF/EPUB thumbnails work outside full GNOME (e.g. Niri). Add print-manager to Printing-Support for KDE System Settings printer integration.

Fixes #157, #202