### PR TITLE
Replace lightdm-gtk-greeter with lightdm-slick-greeter for Cinnamon

### DIFF
--- a/src/modules/netinstall/netinstall.yaml
+++ b/src/modules/netinstall/netinstall.yaml
@@ -367,7 +367,7 @@
     - gnome-terminal
     - metacity
     - lightdm
-    - lightdm-gtk-greeter
+    - lightdm-slick-greeter
 - name: "Budgie-Desktop"
   description: "Budgie - an independent, familiar, and modern desktop."
   description[de]: "Budgie Desktop ist ein funktionsreicher, moderner Desktop. Das Design von Budgie setzt auf Einfachheit, Minimalismus und Eleganz."


### PR DESCRIPTION
Slick greeter provides a more modern and cohesive out-of-the-box experience for the Cinnamon desktop compared to the standard GTK greeter.