### PR TITLE
fix: set timeout: 3600 on create-pacman-keyring step

### DIFF
--- a/src/modules/shellprocess/shellprocess_initialize_pacman.conf
+++ b/src/modules/shellprocess/shellprocess_initialize_pacman.conf
@@ -12,6 +12,7 @@ script:
    timeout: 3600
    verbose: true
  - command: "bash /etc/calamares/scripts/create-pacman-keyring"
+   timeout: 3600
    verbose: true
  - "mkdir -p ${ROOT}/etc/pacman.d/"
  - "cp /etc/pacman.d/mirrorlist ${ROOT}/etc/pacman.d/"


### PR DESCRIPTION
## Summary

Fixes #236.

`create-pacman-keyring` had no explicit timeout, so it used the module default of **30 seconds**. The script runs `pacman-key --init` (entropy generation) plus two `pacman -Sy` retry loops to download `cachyos-keyring` and `archlinux-keyring`. On physical hardware this reliably exceeds 30 seconds, aborting the installation at the "initialize pacman" step.

`update-mirrorlist` already has `timeout: 3600` for exactly this reason. This PR applies the same setting to `create-pacman-keyring`.

## Change

```yaml
# before
 - command: "bash /etc/calamares/scripts/create-pacman-keyring"
   verbose: true

# after
 - command: "bash /etc/calamares/scripts/create-pacman-keyring"
   timeout: 3600
   verbose: true
```

One line added; no logic changed.