### PR TITLE
scripts/detect-architecture: Fast-fail check on Zen4+ if CPU does not support AVX512

### DIFF
--- a/src/modules/shellprocess/shellprocess-before-online.conf
+++ b/src/modules/shellprocess/shellprocess-before-online.conf
@@ -40,5 +40,5 @@ i18n:
 dontChroot: true
 timeout: 10
 script:
-    - command: "cp /etc/pacman.conf ${ROOT}/etc/pacman.conf"
+    - command: "cp /etc/pacman-more.conf ${ROOT}/etc/pacman.conf"
     - command: "/etc/calamares/scripts/detect-architecture ${ROOT}/etc/pacman.conf"

--- a/src/scripts/detect-architecture
+++ b/src/scripts/detect-architecture
@@ -8,14 +8,16 @@ is_zen45() {
     local family="$(grep -Po 'cpu family\s+:\s+\K([0-9]+)' /proc/cpuinfo | head -n1)"
     local model="$(grep -Po 'model\s+:\s+\K([0-9]+)' /proc/cpuinfo | head -n1)"
 
+    if ! grep -q -w "avx512f" /proc/cpuinfo; then
+        return 1
+    fi
+
     case "$family" in
         $((0x19))) # Zen 4
             if ((model <= 0x0f)); then
                 return 1
             elif ((model >= 0x10 && model <= 0x1f)) ||
                 ((model >= 0x60 && model <= 0xaf)); then
-                return 0
-            elif grep -q -w "avx512f" /proc/cpuinfo; then
                 return 0
             fi
             ;;


### PR DESCRIPTION
There is a very strange issue, reproduced only on CI runs to test our ISO, see https://github.com/CachyOS/CachyOS-Live-ISO/pull/105. Failures are only observed when using AMD EPYC 9V74, which, according to the public information, is actually considered Zen 4 CPU, but when launched in GitHub Actions it does not have AVX512 instructions. It may be a deliberate restriction by the GitHub hypervisor, but in one way or another it results in test failures. 