### PR TITLE
netinstall: Remove paru

### DIFF
--- a/src/modules/netinstall/netinstall.yaml
+++ b/src/modules/netinstall/netinstall.yaml
@@ -79,7 +79,6 @@
           - pkgfile
           - rebuild-detector
           - reflector
-          - paru
           - shelly
       - name: "desktop integration"
         description: "Useful helper tools and libs for desktop usage"


### PR DESCRIPTION
Merge it shortly before new release


CachyOS is setting now on Shelly GUI and Shelly CLI and paru is not needed anymore. Paru is also largely unmaintained nowadays and no new features are coming in.

We should provide the user some instructions in the wiki about shelly, so they can easily use it.
