### PR TITLE
packagechooserq: expose accessible role/description for Switch controls

### DIFF
--- a/src/modules/packagechooserq/packagechooserq.qml
+++ b/src/modules/packagechooserq/packagechooserq.qml
@@ -61,6 +61,10 @@ Item {
                     hoverEnabled: true
                     ButtonGroup.group: switchGroup
 
+                    Accessible.role: Accessible.RadioButton
+                    Accessible.description: qsTr("LibreOffice is a powerful and free office suite, used by millions of people around the world. It includes several applications that make it the most versatile Free and Open Source office suite on the market. Default option.")
+                    Accessible.onPressAction: toggle()
+
                     indicator: Rectangle {
                         implicitWidth: 40
                         implicitHeight: 14
@@ -122,6 +126,10 @@ Item {
                     checked: false
                     hoverEnabled: true
                     ButtonGroup.group: switchGroup
+
+                    Accessible.role: Accessible.RadioButton
+                    Accessible.description: qsTr("If you don't want to install an office suite, just select No Office Suite. You can always add one (or more) later on your installed system as the need arrives.")
+                    Accessible.onPressAction: toggle()
 
                     indicator: Rectangle {
                         implicitWidth: 40
@@ -186,6 +194,10 @@ Item {
                     checked: false
                     hoverEnabled: true
                     ButtonGroup.group: switchGroup
+
+                    Accessible.role: Accessible.RadioButton
+                    Accessible.description: qsTr("Create a minimal Desktop install, remove all extra applications and decide later on what you would like to add to your system. Examples of what won't be on such an install, there will be no Office Suite, no media players, no image viewer or print support. It will be just a desktop, file browser, package manager, text editor and simple web-browser.")
+                    Accessible.onPressAction: toggle()
 
                     indicator: Rectangle {
                         implicitWidth: 40


### PR DESCRIPTION
## Summary
- Qt Quick's `Switch` defaults `Accessible.role` to `CheckBox`, but the three switches in the package chooser sit inside an exclusive `ButtonGroup` and behave as radio buttons — so screen readers announced the wrong role.
- Each switch's description `Text` was a sibling element, invisible to accessibility tools.
- Adds `Accessible.role: Accessible.RadioButton`, `Accessible.description`, and `Accessible.onPressAction: toggle()` to each of the three `Switch` controls in `packagechooserq.qml`.

Fixes #208

## Test plan
- [x] `qmllint` run against the file: zero syntax errors (before and after the change)
- [ ] Manual screen reader (Orca) testing — I don't have a built Calamares environment to run this live; would appreciate a maintainer or @RealAmethyst/@Keithcat1 confirming the fix in a live install