### PR TITLE
netinstall: Add pipewire-jack

### DIFF
--- a/src/modules/netinstall/netinstall.yaml
+++ b/src/modules/netinstall/netinstall.yaml
@@ -133,6 +133,7 @@
           - alsa-utils
           - pavucontrol
           - pipewire-pulse
+          - pipewire-jack
           - wireplumber
           - pipewire-alsa
           - realtime-privileges


### PR DESCRIPTION
Since CachyOS uses PipeWire by default (along with `pipewire-pulse` and `pipewire-alsa`), shipping `pipewire-jack` completes the stack.