### PR TITLE
netinstall: switch to ghostty on gnome

### DIFF
--- a/src/modules/netinstall/netinstall.yaml
+++ b/src/modules/netinstall/netinstall.yaml
@@ -258,7 +258,8 @@
     - gdm
     - gnome-text-editor
     - gnome-backgrounds
-    - ptyxis
+    - ghostty
+    - ghostty-nautilus
     - gnome-control-center
     - gnome-keyring
     - gnome-shell


### PR DESCRIPTION
Ghostty brings GPU acceleration and lower latency to Gnome without breaking the desktop's look, thanks to its native GTK4 integration.
Unlike Ptyxis, it supports modern terminal protocols out of the box.