### PR TITLE
keyboard: persist XKB state in vconsole.conf

### DIFF
--- a/src/modules/keyboard/SetKeyboardLayoutJob.cpp
+++ b/src/modules/keyboard/SetKeyboardLayoutJob.cpp
@@ -29,6 +29,8 @@
 #include <QSettings>
 #include <QTextStream>
 
+#include <algorithm>
+
 namespace
 {
 QStringList
@@ -36,6 +38,12 @@ removeEmpty( QStringList&& list )
 {
     list.removeAll( QString() );
     return list;
+}
+
+QString
+envAssignment( const QString& key, const QString& value )
+{
+    return key + '=' + value;
 }
 
 }  // namespace
@@ -54,6 +62,32 @@ variantList( const AdditionalLayoutInfo& additionalLayoutInfo, const QString& va
         variants.clear();
     }
     return variants;
+}
+
+STATICTEST QStringList
+vconsoleXkbLines( const QString& model,
+                  const QStringList& layouts,
+                  const QStringList& variants,
+                  const QString& options )
+{
+    QStringList lines;
+    if ( !layouts.isEmpty() )
+    {
+        lines << envAssignment( QStringLiteral( "XKBLAYOUT" ), layouts.join( "," ) );
+    }
+    if ( !model.isEmpty() )
+    {
+        lines << envAssignment( QStringLiteral( "XKBMODEL" ), model );
+    }
+    if ( !variants.isEmpty() )
+    {
+        lines << envAssignment( QStringLiteral( "XKBVARIANT" ), variants.join( "," ) );
+    }
+    if ( !options.isEmpty() )
+    {
+        lines << envAssignment( QStringLiteral( "XKBOPTIONS" ), options );
+    }
+    return lines;
 }
 
 SetKeyboardLayoutJob::SetKeyboardLayoutJob( const QString& model,
@@ -221,6 +255,9 @@ SetKeyboardLayoutJob::writeVConsoleData( const QString& vconsoleConfPath, const 
         cDebug() << "Trying to use X11 layout" << m_layout << "as the virtual console layout";
         keymap = m_layout;
     }
+    const QStringList layouts = removeEmpty( { m_additionalLayoutInfo.additionalLayout, m_layout } );
+    const QStringList variants = variantList( m_additionalLayoutInfo, m_variant );
+    const QStringList xkbLines = vconsoleXkbLines( m_model, layouts, variants, m_additionalLayoutInfo.groupSwitcher );
 
     QStringList existingLines;
 
@@ -228,7 +265,11 @@ SetKeyboardLayoutJob::writeVConsoleData( const QString& vconsoleConfPath, const 
     QFile file( vconsoleConfPath );
     if ( file.exists() )
     {
-        file.open( QIODevice::ReadOnly | QIODevice::Text );
+        if ( !file.open( QIODevice::ReadOnly | QIODevice::Text ) )
+        {
+            cError() << "Could not open" << file.fileName() << "for reading.";
+            return false;
+        }
         QTextStream stream( &file );
         while ( !stream.atEnd() )
         {
@@ -250,12 +291,24 @@ SetKeyboardLayoutJob::writeVConsoleData( const QString& vconsoleConfPath, const 
     }
     QTextStream stream( &file );
     bool found = false;
+    const QStringList replacedKeys = { QStringLiteral( "KEYMAP=" ),
+                                       QStringLiteral( "XKBLAYOUT=" ),
+                                       QStringLiteral( "XKBMODEL=" ),
+                                       QStringLiteral( "XKBVARIANT=" ),
+                                       QStringLiteral( "XKBOPTIONS=" ) };
     for ( const QString& existingLine : std::as_const( existingLines ) )
     {
         if ( existingLine.trimmed().startsWith( "KEYMAP=" ) )
         {
-            stream << "KEYMAP=" << keymap << '\n';
+            stream << envAssignment( QStringLiteral( "KEYMAP" ), keymap ) << '\n';
             found = true;
+        }
+        else if ( std::any_of( replacedKeys.cbegin(),
+                               replacedKeys.cend(),
+                               [ &existingLine ]( const QString& key )
+                               { return existingLine.trimmed().startsWith( key ); } ) )
+        {
+            continue;
         }
         else
         {
@@ -265,12 +318,17 @@ SetKeyboardLayoutJob::writeVConsoleData( const QString& vconsoleConfPath, const 
     // Add a KEYMAP= line if there wasn't any
     if ( !found )
     {
-        stream << "KEYMAP=" << keymap << '\n';
+        stream << envAssignment( QStringLiteral( "KEYMAP" ), keymap ) << '\n';
+    }
+    for ( const QString& xkbLine : xkbLines )
+    {
+        stream << xkbLine << '\n';
     }
     stream.flush();
     file.close();
 
-    cDebug() << Logger::SubEntry << "Written KEYMAP=" << keymap << "to vconsole.conf" << stream.status();
+    cDebug() << Logger::SubEntry << "Written KEYMAP=" << keymap << "and XKB settings to vconsole.conf"
+             << stream.status();
 
     return ( stream.status() == QTextStream::Ok );
 }

--- a/src/modules/keyboard/Tests.cpp
+++ b/src/modules/keyboard/Tests.cpp
@@ -14,6 +14,8 @@
 // Internals of SetKeyboardLayoutJob.cpp
 extern QString findLegacyKeymap( const QString& layout, const QString& model, const QString& variant );
 extern QStringList variantList( const AdditionalLayoutInfo& additionalLayoutInfo, const QString& variant );
+extern QStringList
+vconsoleXkbLines( const QString& model, const QStringList& layouts, const QStringList& variants, const QString& options );
 
 class KeyboardLayoutTests : public QObject
 {
@@ -29,6 +31,8 @@ private Q_SLOTS:
     void testSimpleLayoutLookup();
     void testVariantList_data();
     void testVariantList();
+    void testVConsoleXkbLines_data();
+    void testVConsoleXkbLines();
 };
 
 void
@@ -101,6 +105,40 @@ KeyboardLayoutTests::testVariantList()
     additionalLayoutInfo.additionalVariant = additionalVariant;
 
     QCOMPARE( variantList( additionalLayoutInfo, variant ), expected );
+}
+
+void
+KeyboardLayoutTests::testVConsoleXkbLines_data()
+{
+    QTest::addColumn< QString >( "model" );
+    QTest::addColumn< QStringList >( "layouts" );
+    QTest::addColumn< QStringList >( "variants" );
+    QTest::addColumn< QString >( "options" );
+    QTest::addColumn< QStringList >( "expected" );
+
+    QTest::newRow( "simple layout" ) << QStringLiteral( "pc105" ) << QStringList { QStringLiteral( "de" ) }
+                                     << QStringList {} << QString()
+                                     << QStringList { QStringLiteral( "XKBLAYOUT=de" ),
+                                                      QStringLiteral( "XKBMODEL=pc105" ) };
+    QTest::newRow( "additional layout" )
+        << QStringLiteral( "pc105" ) << QStringList { QStringLiteral( "us" ), QStringLiteral( "ua" ) }
+        << QStringList { QString(), QStringLiteral( "phonetic" ) } << QStringLiteral( "grp:alt_shift_toggle" )
+        << QStringList { QStringLiteral( "XKBLAYOUT=us,ua" ),
+                         QStringLiteral( "XKBMODEL=pc105" ),
+                         QStringLiteral( "XKBVARIANT=,phonetic" ),
+                         QStringLiteral( "XKBOPTIONS=grp:alt_shift_toggle" ) };
+}
+
+void
+KeyboardLayoutTests::testVConsoleXkbLines()
+{
+    QFETCH( QString, model );
+    QFETCH( QStringList, layouts );
+    QFETCH( QStringList, variants );
+    QFETCH( QString, options );
+    QFETCH( QStringList, expected );
+
+    QCOMPARE( vconsoleXkbLines( model, layouts, variants, options ), expected );
 }
 
 


### PR DESCRIPTION
systemd-localed can read XKB model/layout/variant/options from /etc/vconsole.conf and may report the X11 layout as unset when only the legacy Xorg keyboard snippet is written.

Write the selected XKB state alongside KEYMAP in vconsole.conf, replacing any stale XKB entries there. This matches the state produced by localectl set-x11-keymap and keeps installed systems using the selected keyboard layout after boot.

xkeyboard-config major upgrade broke it.