### PR TITLE
[GNOME] Removed file-roller

### DIFF
--- a/src/modules/netinstall/netinstall.yaml
+++ b/src/modules/netinstall/netinstall.yaml
@@ -271,7 +271,6 @@
         packages:
           - papers
           - loupe
-          - file-roller
           - simple-scan
           - gnome-disk-utility
           - gnome-power-manager


### PR DESCRIPTION
Base Nautilus can decompress and compress files and directories without need of external tools.

Current settings don't even default to opening such files with File Roller so most likely it'll be missed.