### PR TITLE
Add gvfs-mtp to netinstall.yaml dependencies to cosmic

### DIFF
--- a/src/modules/netinstall/netinstall.yaml
+++ b/src/modules/netinstall/netinstall.yaml
@@ -331,6 +331,7 @@
     - xdg-desktop-portal-gtk
     - gnome-keyring
     - xorg-xwayland
+    - gvfs-mtp
 - name: "Niri"
   description: "A scrollable-tiling Wayland compositor."
   description[de]: "Ein Wayland-Kompositor mit scrollbarem Tiling."


### PR DESCRIPTION
Added 'gvfs-mtp' to the list of dependencies. resolves https://github.com/CachyOS/distribution/issues/519