### PR TITLE
initcpiocfg: Remove kms hook by default

### DIFF
--- a/src/modules/initcpiocfg/initcpiocfg.conf
+++ b/src/modules/initcpiocfg/initcpiocfg.conf
@@ -27,7 +27,7 @@ useSystemdHook: true
 hooks:
     prepend: [ bogus ]
     append: [ bogus ]
-    remove: [ bogus ]
+    remove: [ bogus kms ]
 
 #
 # In some cases, you may want to use a different source


### PR DESCRIPTION
Depend on https://github.com/CachyOS/chwd/pull/236 and https://github.com/CachyOS/cachyos-calamares/pull/204