### PR TITLE
partition: Decrease size of ESP partiton for Limine

### DIFF
--- a/src/modules/partition/partition.conf
+++ b/src/modules/partition/partition.conf
@@ -72,12 +72,3 @@ bootloaderOverrides:
       luksGeneration: luks2
       initialSwapChoice: none
       initialPartitioningChoice: none
-    - name: limine
-      allowZfsEncryption: true
-      defaultFileSystemType:  "btrfs"
-      availableFileSystemTypes:  ["btrfs","xfs","ext4","f2fs","zfs"]
-      efiSystemPartition: "/boot"
-      efiSystemPartitionSize: 4096M
-      luksGeneration: luks2
-      initialSwapChoice: none
-      initialPartitioningChoice: none


### PR DESCRIPTION
Depends on https://github.com/CachyOS/cachyos-calamares/pull/271

Without using kms hook on my machine vmlinuz and initramfs take only ~33 Mb, so we don't need to use such big ESP partition for Limine.  2 GB partition allows ~60 simultaneously installed kernels or snapshots to be placed, which sounds like a reasonable number. 